### PR TITLE
Adjust ObservableArray move to index before inserting new value

### DIFF
--- a/Sources/Bond/Collections/ObservableArray.swift
+++ b/Sources/Bond/Collections/ObservableArray.swift
@@ -169,8 +169,9 @@ public class MutableObservableArray<Item>: ObservableArray<Item> {
     /// Move the element at index `i` to index `toIndex`.
     public func moveItem(from fromIndex: Int, to toIndex: Int) {
         lock.lock(); defer { lock.unlock() }
+        let adjustedToIndex = (fromIndex <= toIndex) ? toIndex - 1 : toIndex
         let item = array.remove(at: fromIndex)
-        array.insert(item, at: toIndex)
+        array.insert(item, at: adjustedToIndex)
         subject.next(ObservableArrayEvent(change: .move(fromIndex, toIndex), source: self))
     }
 


### PR DESCRIPTION
I expect that a move function allows me to move an arbitrary object/index to any other index in the array, without having to do extra processing. 

This PR changes the behaviour of  `MutableObservableArray.moveItem(from:to:)` so that the `toIndex` is adjusted if it is a lower index than that of the `fromIndex`.