### PR TITLE
PR 526 - Changed macOS version number

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -1465,6 +1465,7 @@
 				INFOPLIST_FILE = "Supporting Files/$(PRODUCT_NAME)-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = ReactiveKit.Bond;
 				PRODUCT_NAME = Bond;
 				SDKROOT = macosx;
@@ -1491,6 +1492,7 @@
 				INFOPLIST_FILE = "Supporting Files/$(PRODUCT_NAME)-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = ReactiveKit.Bond;
 				PRODUCT_NAME = Bond;
 				SDKROOT = macosx;


### PR DESCRIPTION
The current Bond-macOS target uses a minimum version number of `10.10` and therefore doesn't match Differ's minimum requirement of 10.11 -- and thus doesn't compile.

```
/Users/.../Documents/Development/NPVTech/GitHub/Bond/Sources/Bond/Collections/ObservableArray.swift:26:8: Module file's minimum deployment target is OS X v10.11: /Users/.../Library/Developer/Xcode/DerivedData/Bond-eqmfknejxnrlotembewkhhlngesv/Build/Products/Debug/Differ.framework/Modules/Differ.swiftmodule/x86_64.swiftmodule
```