### PR TITLE
Replace KVO with controlEvent for NSControl.reactive.objectValue derived properties

### DIFF
--- a/Sources/Bond/AppKit/NSControl.swift
+++ b/Sources/Bond/AppKit/NSControl.swift
@@ -94,7 +94,7 @@ public extension ReactiveExtensions where Base: NSControl {
 
     public var objectValue: DynamicSubject<Any?> {
         return dynamicSubject(
-            signal: keyPath(#keyPath(NSControl.objectValue), ofType: Optional<Any>.self).eraseType(),
+            signal: controlEvent.eraseType(),
             triggerEventOnSetting: false,
             get: { $0.objectValue },
             set: { $0.objectValue = $1 }
@@ -103,7 +103,7 @@ public extension ReactiveExtensions where Base: NSControl {
 
     public var stringValue: DynamicSubject<String> {
         return dynamicSubject(
-            signal: keyPath(#keyPath(NSControl.stringValue), ofType: String.self).eraseType(),
+            signal: objectValue.eraseType(),
             triggerEventOnSetting: false,
             get: { $0.stringValue },
             set: { $0.stringValue = $1 }
@@ -112,7 +112,7 @@ public extension ReactiveExtensions where Base: NSControl {
 
     public var attributedStringValue: DynamicSubject<NSAttributedString> {
         return dynamicSubject(
-            signal: keyPath(#keyPath(NSControl.attributedStringValue), ofType: NSAttributedString.self).eraseType(),
+            signal: objectValue.eraseType(),
             triggerEventOnSetting: false,
             get: { $0.attributedStringValue },
             set: { $0.attributedStringValue = $1 }
@@ -121,7 +121,7 @@ public extension ReactiveExtensions where Base: NSControl {
 
     public var integerValue: DynamicSubject<Int> {
         return dynamicSubject(
-            signal: keyPath(#keyPath(NSControl.integerValue), ofType: Int.self).eraseType(),
+            signal: objectValue.eraseType(),
             triggerEventOnSetting: false,
             get: { $0.integerValue },
             set: { $0.integerValue = $1 }
@@ -130,7 +130,7 @@ public extension ReactiveExtensions where Base: NSControl {
 
     public var floatValue: DynamicSubject<Float> {
         return dynamicSubject(
-            signal: keyPath(#keyPath(NSControl.floatValue), ofType: Float.self).eraseType(),
+            signal: objectValue.eraseType(),
             triggerEventOnSetting: false,
             get: { $0.floatValue },
             set: { $0.floatValue = $1 }
@@ -139,7 +139,7 @@ public extension ReactiveExtensions where Base: NSControl {
 
     public var doubleValue: DynamicSubject<Double> {
         return dynamicSubject(
-            signal: keyPath(#keyPath(NSControl.doubleValue), ofType: Double.self).eraseType(),
+            signal: objectValue.eraseType(),
             triggerEventOnSetting: false,
             get: { $0.doubleValue },
             set: { $0.doubleValue = $1 }


### PR DESCRIPTION
This PR replaces key-value observation (KVO) with `controlEvent` when tracking changes to NSControl `objectValue` derivative properties. 

I noticed that `NSTextField.reactive.stringValue` was not posting any events.