### PR TITLE
Add support for NSGestureRecognizer on macOS

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		16887E3A1D744ABB00EDA099 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16887E391D744ABB00EDA099 /* AppDelegate.swift */; };
 		16887E441D744ABB00EDA099 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 16887E421D744ABB00EDA099 /* LaunchScreen.storyboard */; };
 		75CA9E9220678E600011E5BB /* UISearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CA9E9120678E600011E5BB /* UISearchBar.swift */; };
+		901E85A1214A125A00F03A80 /* NSGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901E85A0214A125A00F03A80 /* NSGestureRecognizer.swift */; };
 		9025DCAB1F981693007B7689 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0220091F8BE898002F8380 /* Property.swift */; };
 		9025DCB01F981694007B7689 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0220091F8BE898002F8380 /* Property.swift */; };
 		9025DCB11F9816A7007B7689 /* UIAccessibilityIdentification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC86E9AE1E9145CC008563B2 /* UIAccessibilityIdentification.swift */; };
@@ -323,6 +324,7 @@
 		16D30EAE1D6591D300C2435D /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		16D30ED61D65D11900C2435D /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		75CA9E9120678E600011E5BB /* UISearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISearchBar.swift; sourceTree = "<group>"; };
+		901E85A0214A125A00F03A80 /* NSGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSGestureRecognizer.swift; sourceTree = "<group>"; };
 		90A3FAC21E0C8D8B0086A7F1 /* Differ.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Differ.xcodeproj; path = Carthage/Checkouts/Differ/Differ.xcodeproj; sourceTree = "<group>"; };
 		90C04D021E8F0A97000077C8 /* Bond-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Bond-Info.plist"; sourceTree = "<group>"; };
 		90C04D031E8F0A97000077C8 /* Bond.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bond.h; sourceTree = "<group>"; };
@@ -629,6 +631,7 @@
 				90C04D261E8F0B1D000077C8 /* NSButton.swift */,
 				90C04D271E8F0B1D000077C8 /* NSColorWell.swift */,
 				90C04D281E8F0B1D000077C8 /* NSControl.swift */,
+				901E85A0214A125A00F03A80 /* NSGestureRecognizer.swift */,
 				90C04D291E8F0B1D000077C8 /* NSImageView.swift */,
 				90C04D2B1E8F0B1D000077C8 /* NSMenuItem.swift */,
 				90C04D2E1E8F0B1D000077C8 /* NSPopUpButton.swift */,
@@ -984,6 +987,7 @@
 				75CA9E9220678E600011E5BB /* UISearchBar.swift in Sources */,
 				90C04DC31E8F0B97000077C8 /* UITextView.swift in Sources */,
 				90A443131E9055D200D611FE /* NSTextView.swift in Sources */,
+				901E85A1214A125A00F03A80 /* NSGestureRecognizer.swift in Sources */,
 				90C04DB21E8F0B97000077C8 /* UIButton.swift in Sources */,
 				070FE2741F0138180031B7BD /* NSLayoutConstraint.swift in Sources */,
 				90C04DB61E8F0B97000077C8 /* UIGestureRecognizer.swift in Sources */,

--- a/Sources/Bond/AppKit/NSGestureRecognizer.swift
+++ b/Sources/Bond/AppKit/NSGestureRecognizer.swift
@@ -1,0 +1,123 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2016 Tony Arnold (@tonyarnold)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#if os(macOS)
+
+import AppKit
+import ReactiveKit
+
+extension NSGestureRecognizer: BindingExecutionContextProvider {
+    public var bindingExecutionContext: ExecutionContext { return .immediateOnMain }
+}
+
+public extension ReactiveExtensions where Base: NSGestureRecognizer {
+    public var isEnabled: Bond<Bool> {
+        return bond { $0.isEnabled = $1 }
+    }
+}
+
+public extension ReactiveExtensions where Base: NSView {
+    public func addGestureRecognizer<T: NSGestureRecognizer>(_ gestureRecognizer: T) -> SafeSignal<T> {
+        let base = self.base
+        return Signal { [weak base] observer in
+            guard let base = base else {
+                observer.completed()
+                return NonDisposable.instance
+            }
+            let target = BNDGestureTarget(view: base, gestureRecognizer: gestureRecognizer) { recog in
+                // swiftlint:disable:next force_cast
+                observer.next(recog as! T)
+            }
+            return BlockDisposable {
+                target.unregister()
+            }
+        }
+        .take(until: base.deallocated)
+    }
+
+    public func clickGesture(numberOfClicks: Int = 1, numberOfTouches: Int = 1) -> SafeSignal<NSClickGestureRecognizer> {
+        let gesture = NSClickGestureRecognizer()
+        gesture.numberOfClicksRequired = numberOfClicks
+        gesture.numberOfTouchesRequired = numberOfTouches
+        return addGestureRecognizer(gesture)
+    }
+
+    public func magnificationGesture(magnification: CGFloat = 1.0, numberOfTouches: Int = 1) -> SafeSignal<NSMagnificationGestureRecognizer> {
+        let gesture = NSMagnificationGestureRecognizer()
+        gesture.magnification = magnification
+        return addGestureRecognizer(gesture)
+    }
+
+    public func panGesture(buttonMask: Int = 0x01, numberOfTouches: Int = 1) -> SafeSignal<NSPanGestureRecognizer> {
+        let gesture = NSPanGestureRecognizer()
+        gesture.buttonMask = buttonMask
+        gesture.numberOfTouchesRequired = numberOfTouches
+        return addGestureRecognizer(gesture)
+    }
+
+    public func pressGesture(buttonMask: Int = 0x01, minimumPressDuration: TimeInterval = NSEvent.doubleClickInterval, allowableMovement: CGFloat = 10.0, numberOfTouches: Int = 1) -> SafeSignal<NSPressGestureRecognizer> {
+        let gesture = NSPressGestureRecognizer()
+        gesture.buttonMask = buttonMask
+        gesture.minimumPressDuration = minimumPressDuration
+        gesture.allowableMovement = allowableMovement
+        gesture.numberOfTouchesRequired = numberOfTouches
+        return addGestureRecognizer(gesture)
+    }
+
+    public func rotationGesture() -> SafeSignal<NSRotationGestureRecognizer> {
+        return addGestureRecognizer(NSRotationGestureRecognizer())
+    }
+}
+
+@objc private class BNDGestureTarget: NSObject {
+    private weak var view: NSView?
+    private let observer: (NSGestureRecognizer) -> Void
+    private let gestureRecognizer: NSGestureRecognizer
+
+    fileprivate init(view: NSView, gestureRecognizer: NSGestureRecognizer, observer: @escaping (NSGestureRecognizer) -> Void) {
+        self.view = view
+        self.gestureRecognizer = gestureRecognizer
+        self.observer = observer
+
+        super.init()
+
+        gestureRecognizer.target = self
+        gestureRecognizer.action = #selector(actionHandler(recogniser:))
+        view.addGestureRecognizer(gestureRecognizer)
+    }
+
+    @objc private func actionHandler(recogniser: NSGestureRecognizer) {
+        observer(recogniser)
+    }
+
+    fileprivate func unregister() {
+        view?.removeGestureRecognizer(gestureRecognizer)
+    }
+
+    deinit {
+        unregister()
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adds support for `NSGestureRecognizer` subclasses for macOS in an almost identical way to `UIGestureRecognizer` on iOS.