### PR TITLE
bump Differ to v1.3.0

### DIFF
--- a/Bond.podspec
+++ b/Bond.podspec
@@ -30,6 +30,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "ReactiveKit", "~> 3.9"
-  s.dependency "Differ", "~> 1.2"
+  s.dependency "Differ", "~> 1.3"
 
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "DeclarativeHub/ReactiveKit" ~> 3.9
-github "tonyarnold/Differ" ~> 1.2
+github "tonyarnold/Differ" ~> 1.3

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveKit/ReactiveKit.git", .upToNextMajor(from: "3.9.0")),
-        .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.2.0"))
+        .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.3.0"))
     ],
     targets: [
         .target(name: "BNDProtocolProxyBase"),


### PR DESCRIPTION
This makes Bond use Swift 4.2 compatible version of Differ.