### PR TITLE
#fix : DynamicSubject did not notify it’s subject when changed via bi-binding

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -1518,7 +1518,6 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BUILDING_WITH_XCODE";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1577,7 +1576,6 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = BUILDING_WITH_XCODE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
 				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
@@ -1604,14 +1602,12 @@
 				);
 				INFOPLIST_FILE = "Supporting Files/$(PRODUCT_NAME)-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ReactiveKit.Bond;
 				PRODUCT_NAME = Bond;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1632,13 +1628,11 @@
 				);
 				INFOPLIST_FILE = "Supporting Files/$(PRODUCT_NAME)-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = ReactiveKit.Bond;
 				PRODUCT_NAME = Bond;
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+# fix : DynamicSubject does not notify it’s subject when changed via bidirectionalMap()
+
+Hi, 
+
+Here an example that binds a slider to dynamic pubject (colorDynamicSubject) to change it's alpha.
+colorDynamicSubject when bound to a label would not be notified of any changes made by slider's value (ui change), only by changes to the original dynamic subject, even though it would still call the setter.
+I think anything else linked to the same colorDynamicSubject should also be notified of the 'setting'
+
+// e.g. track silder's value to change a colour's alph:
+var colorDynamicSubject : DynamicSubject
+...
+colorDynamicSubject
+.bidirectionalMap(
+to: { $0?.rgb.alpha ?? 0 },
+from: { UIColor(hue: somecolor, saturation: 1, brightness: 1, alpha: $0) } // <-- map alpha
+)
+.bidirectionalBind(to: slider.reactive.value()) / <-- here's the slider's value change.
+
+colorDynamicSubject.bidirectionalBind(to: label) // <-- (another bind to the original subject) display the colour somewhere.
+
+without the change the slider will change the dynamic subject, but the setting of the subject will not notify anything else also linked to the subject. (e.i, the directionalMap)
+
+Let me know if I need to clarify more.
+
+Leslie Godwin
+
 # Bond, Swift Bond
 
 [![Platform](https://img.shields.io/cocoapods/p/Bond.svg?style=flat)](http://cocoadocs.org/docsets/Bond/)

--- a/Sources/Bond/DynamicSubject.swift
+++ b/Sources/Bond/DynamicSubject.swift
@@ -166,8 +166,13 @@ public struct FailableDynamicSubject<Element, Error: Swift.Error>: SubjectProtoc
                     return .failure(error)
                 }
             },
-            set: { [setter] (target, element) in
+            set: { [setter, triggerEventOnSetting, subject] (target, element) in
+                
                 setter(target, setTransform(element))
+                
+                if triggerEventOnSetting {
+                    subject.next(())
+                }
             }
         )
     }

--- a/Sources/Bond/DynamicSubject.swift
+++ b/Sources/Bond/DynamicSubject.swift
@@ -170,8 +170,8 @@ public struct FailableDynamicSubject<Element, Error: Swift.Error>: SubjectProtoc
                 
                 setter(target, setTransform(element))
                 
-                if triggerEventOnSetting {
-                    subject.next(())
+                if triggerEventOnSetting { // <-- fix
+                    subject.send(())
                 }
             }
         )


### PR DESCRIPTION
DynamicSubject did not notify it’s subject when changed via bidirectionalMap().

```swift
// e.g. track silder's value to change a colour's alph:
colorDynamicSubject
    .bidirectionalMap(
        to:   { $0?.rgb.alpha ?? 0 },
        from: { UIColor(hue: somecolor, saturation: 1, brightness: 1, alpha: $0) } // <-- map alpha
    )
    .bidirectionalBind(to: slider.reactive.value()) // <-- here's the slider's value change.

colorDynamicSubject.bidirectionalBind(to: label) // <-- (another bind to the original subject) display the colour somewhere.
```

without the change the slider will change the dynamic subject, but the setting of the subject will not notify anything else also linked to the subject. (e.i, the 