### PR TITLE
Add data source binding extensions to UIPickerView

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -176,6 +176,9 @@
 		90C04DC21E8F0B97000077C8 /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D531E8F0B1D000077C8 /* UITextField.swift */; };
 		90C04DC31E8F0B97000077C8 /* UITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D541E8F0B1D000077C8 /* UITextView.swift */; };
 		90C04DC41E8F0B97000077C8 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D551E8F0B1D000077C8 /* UIView.swift */; };
+		E58FBB8D22187FD700339211 /* UIPickerView+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E58FBB8C22187FD700339211 /* UIPickerView+DataSource.swift */; };
+		E5BAF71221C68394008C78E2 /* UIPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5BAF71121C68394008C78E2 /* UIPickerView.swift */; };
+		E5C968A9221926D70026D7D8 /* UIPickerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C968A8221926D70026D7D8 /* UIPickerViewTests.swift */; };
 		EC02200A1F8BE898002F8380 /* Property+BidirectionalMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0220091F8BE898002F8380 /* Property+BidirectionalMap.swift */; };
 		EC0D8D2321C697D1003F8EF2 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0D8D2221C697D1003F8EF2 /* Deprecations.swift */; };
 		EC0D8D2B21C69BC6003F8EF2 /* UITableView+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0D8D2A21C69BC6003F8EF2 /* UITableView+DataSource.swift */; };
@@ -481,6 +484,9 @@
 		90C04DCF1E8F0BA7000077C8 /* UICollectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewTests.swift; sourceTree = "<group>"; };
 		90C04DD01E8F0BA7000077C8 /* UIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitTests.swift; sourceTree = "<group>"; };
 		90C04DD11E8F0BA7000077C8 /* UITableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewTests.swift; sourceTree = "<group>"; };
+		E58FBB8C22187FD700339211 /* UIPickerView+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPickerView+DataSource.swift"; sourceTree = "<group>"; };
+		E5BAF71121C68394008C78E2 /* UIPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIPickerView.swift; sourceTree = "<group>"; };
+		E5C968A8221926D70026D7D8 /* UIPickerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPickerViewTests.swift; sourceTree = "<group>"; };
 		EC0220091F8BE898002F8380 /* Property+BidirectionalMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Property+BidirectionalMap.swift"; sourceTree = "<group>"; };
 		EC0D8D2221C697D1003F8EF2 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		EC0D8D2A21C69BC6003F8EF2 /* UITableView+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+DataSource.swift"; sourceTree = "<group>"; };
@@ -723,6 +729,8 @@
 				EC86E9AE1E9145CC008563B2 /* UIAccessibilityIdentification.swift */,
 				90C04D4A1E8F0B1D000077C8 /* UINavigationBar.swift */,
 				90C04D4B1E8F0B1D000077C8 /* UINavigationItem.swift */,
+				E5BAF71121C68394008C78E2 /* UIPickerView.swift */,
+				E58FBB8C22187FD700339211 /* UIPickerView+DataSource.swift */,
 				90C04D4C1E8F0B1D000077C8 /* UIProgressView.swift */,
 				90C04D4D1E8F0B1D000077C8 /* UIRefreshControl.swift */,
 				90C04D4E1E8F0B1D000077C8 /* UISegmentedControl.swift */,
@@ -792,6 +800,7 @@
 				90C04DC71E8F0BA7000077C8 /* BondTests.swift */,
 				90C04DC81E8F0BA7000077C8 /* DynamicSubjectTests.swift */,
 				90C04DD01E8F0BA7000077C8 /* UIKitTests.swift */,
+				E5C968A8221926D70026D7D8 /* UIPickerViewTests.swift */,
 				90C04DD11E8F0BA7000077C8 /* UITableViewTests.swift */,
 				90C04DCF1E8F0BA7000077C8 /* UICollectionViewTests.swift */,
 				EC6A35E52075FCB600E8F805 /* CollectionChangesetDiffAndPatchTest.swift */,
@@ -1163,10 +1172,12 @@
 				ECBB81FA220EDFDA00C7B7B0 /* OrderedCollectionDiff+IndexPath+Differ.swift in Sources */,
 				ECFF44B42168EC4C00B5EDB0 /* UICollectionView.swift in Sources */,
 				90A4430D1E9055D100D611FE /* NSProgressIndicator.swift in Sources */,
+				E5BAF71221C68394008C78E2 /* UIPickerView.swift in Sources */,
 				90C04DB91E8F0B97000077C8 /* UINavigationBar.swift in Sources */,
 				EC1F12812167CA0D002F0D1B /* UnorderedCollectionChangeset+Dictionary.swift in Sources */,
 				EC02200A1F8BE898002F8380 /* Property+BidirectionalMap.swift in Sources */,
 				90C04DBE1E8F0B97000077C8 /* UISlider.swift in Sources */,
+				E58FBB8D22187FD700339211 /* UIPickerView+DataSource.swift in Sources */,
 				90C04DBC1E8F0B97000077C8 /* UIRefreshControl.swift in Sources */,
 				ECBC51FA216163BA00BE80EC /* TreeNode.swift in Sources */,
 				90C04DBD1E8F0B97000077C8 /* UISegmentedControl.swift in Sources */,
@@ -1238,6 +1249,7 @@
 				ECC4358321612B350002A869 /* ProtocolProxyTests.swift in Sources */,
 				ECC4358721612B480002A869 /* NSObjectTests.swift in Sources */,
 				ECC4358621612B460002A869 /* Helpers.swift in Sources */,
+				E5C968A9221926D70026D7D8 /* UIPickerViewTests.swift in Sources */,
 				ECC4358421612B410002A869 /* BondTests.swift in Sources */,
 				ECC4357E216127490002A869 /* TreeChangesetDiffAndPatchTest.swift in Sources */,
 				EC1746C7216A2BD500955C49 /* UICollectionViewTests.swift in Sources */,

--- a/Sources/Bond/UIKit/UIPickerView+DataSource.swift
+++ b/Sources/Bond/UIKit/UIPickerView+DataSource.swift
@@ -1,0 +1,142 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2016 Srdan Rasic (@srdanrasic)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#if os(iOS) || os(tvOS)
+
+import UIKit
+import ReactiveKit
+
+extension SignalProtocol where Element: SectionedDataSourceChangesetConvertible, Error == NoError {
+
+    /// Binds the signal of data source elements to the given picker view.
+    ///
+    /// - parameters:
+    ///     - pickerView: A picker view that should display the data from the data source.
+    ///     - createTitle: A closure that configures the title for a given picker view row with the given data source at the given index path.
+    /// - returns: A disposable object that can terminate the binding. Safe to ignore - the binding will be automatically terminated when the picker view is deallocated.
+    @discardableResult
+    public func bind(to pickerView: UIPickerView, createTitle: @escaping (Element.Changeset.Collection, Int, Int, UIPickerView) -> String?) -> Disposable {
+        let binder = PickerViewBinderDataSource<Element.Changeset>(createTitle)
+
+        return bind(to: pickerView, using: binder)
+    }
+
+    /// Binds the signal of data source elements to the given table view.
+    ///
+    /// - parameters:
+    ///     - pickerView: A picker view that should display the data from the data source.
+    ///     - binder: A `PickerViewBinderDataSource` or its subclass that will manage the binding.
+    /// - returns: A disposable object that can terminate the binding. Safe to ignore - the binding will be automatically terminated when the picker view is deallocated.
+    @discardableResult
+    public func bind(to pickerView: UIPickerView, using binderDataSource: PickerViewBinderDataSource<Element.Changeset>) -> Disposable {
+        binderDataSource.pickerView = pickerView
+        return bind(to: pickerView) { (_, changeset) in
+            binderDataSource.changeset = changeset.asSectionedDataSourceChangeset
+        }
+    }
+}
+
+extension SignalProtocol where Element: SectionedDataSourceChangesetConvertible, Element.Changeset.Collection: QueryableSectionedDataSourceProtocol, Error == NoError {
+
+    /// Binds the signal of data source elements to the given picker view.
+    ///
+    /// - parameters:
+    ///     - pickerView: A picker view that should display the data from the data source.
+    /// - returns: A disposable object that can terminate the binding. Safe to ignore - the binding will be automatically terminated when the picker view is deallocated.
+    @discardableResult
+    public func bind(to pickerView: UIPickerView) -> Disposable {
+        let createTitle: (Element.Changeset.Collection, Int, Int, UIPickerView) -> String? = { (dataSource, row, component, pickerView) in
+            let indexPath = IndexPath(row: row, section: component)
+            let item = dataSource.item(at: indexPath)
+
+            return String(describing: item)
+        }
+
+        return bind(to: pickerView, using: PickerViewBinderDataSource<Element.Changeset>(createTitle))
+    }
+}
+
+private var PickerViewBinderDataSourceAssociationKey = "PickerViewBinderDataSource"
+
+public class PickerViewBinderDataSource<Changeset: SectionedDataSourceChangeset>: NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
+
+    public var createTitle: ((Changeset.Collection, Int, Int, UIPickerView) -> String?)?
+
+    public var changeset: Changeset? = nil {
+        didSet {
+            pickerView?.reloadAllComponents()
+        }
+    }
+
+    open weak var pickerView: UIPickerView? = nil {
+        didSet {
+            guard let pickerView = pickerView else { return }
+            associateWithPickerView(pickerView)
+        }
+    }
+
+    public override init() {
+        self.createTitle = nil
+    }
+
+    /// - parameter createTitle: A closure that configures the title for a given picker view row with the given data source at the given index path.
+    public init(_ createTitle: @escaping (Changeset.Collection, Int, Int, UIPickerView) -> String?) {
+        self.createTitle = createTitle
+    }
+
+    public func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return changeset?.collection.numberOfSections ?? 0
+    }
+
+    public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return changeset?.collection.numberOfItems(inSection: component) ?? 0
+    }
+
+    open func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        guard let changeset = changeset else { fatalError() }
+        if let createTitle = createTitle {
+            return createTitle(changeset.collection, row, component, pickerView)
+        } else {
+            fatalError("Subclass of PickerViewBinderDataSource should override and implement pickerView(_:titleForRow:forComponent) method if they do not initialize `createTitle` closure.")
+        }
+    }
+
+    private func associateWithPickerView(_ pickerView: UIPickerView) {
+        objc_setAssociatedObject(pickerView, &PickerViewBinderDataSourceAssociationKey, self, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+        if pickerView.reactive.hasProtocolProxy(for: UIPickerViewDataSource.self) {
+            pickerView.reactive.dataSource.forwardTo = self
+        } else {
+            pickerView.dataSource = self
+        }
+
+        if pickerView.reactive.hasProtocolProxy(for: UIPickerViewDelegate.self) {
+            pickerView.reactive.delegate.forwardTo = self
+        } else {
+            pickerView.delegate = self
+        }
+    }
+}
+
+#endif

--- a/Sources/Bond/UIKit/UIPickerView.swift
+++ b/Sources/Bond/UIKit/UIPickerView.swift
@@ -1,0 +1,67 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2016 Srdan Rasic (@srdanrasic)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#if os(iOS)
+
+import UIKit
+import ReactiveKit
+
+public extension ReactiveExtensions where Base: UIPickerView {
+
+    /// A `ProtocolProxy` for the picker view data source.
+    ///
+    /// - Note: Accessing this property for the first time will replace picker view's current data source
+    /// with a protocol proxy object (an object that is stored in this property).
+    /// Current data source will be used as `forwardTo` data source of protocol proxy.
+    public var dataSource: ProtocolProxy {
+        return protocolProxy(for: UIPickerViewDataSource.self, keyPath: \.dataSource)
+    }
+
+    /// A `ProtocolProxy` for the picker view delegate.
+    ///
+    /// - Note: Accessing this property for the first time will replace table view's current delegate
+    /// with a protocol proxy object (an object that is stored in this property).
+    /// Current delegate will be used as `forwardTo` delegate of protocol proxy.
+    public var delegate: ProtocolProxy {
+        return protocolProxy(for: UIPickerViewDelegate.self, keyPath: \.delegate)
+    }
+
+    /// A signal that emits the row and component index of the selected picker view row.
+    ///
+    /// - Note: Uses picker view's `delegate` protocol proxy to observe calls made to `UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)` method.
+    public var selectedRow: SafeSignal<(Int, Int)> {
+        return delegate.signal(
+            for: #selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)),
+            dispatch: { (
+                subject: SafePublishSubject<(Int, Int)>,
+                pickerView: UIPickerView,
+                row: Int,
+                component: Int) -> Void in
+                subject.next((row, component))
+            }
+        )
+    }
+}
+
+#endif

--- a/Tests/BondTests/UIPickerViewTests.swift
+++ b/Tests/BondTests/UIPickerViewTests.swift
@@ -1,0 +1,50 @@
+//
+//  UIPickerViewTests.swift
+//  BondTests
+//
+//  Created by Jonathan Foster on 2/17/19.
+//  Copyright © 2019 Swift Bond. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import XCTest
+import ReactiveKit
+@testable import Bond
+
+class UIPickerViewTests: XCTestCase {
+
+    var array: MutableObservableArray<Int>!
+    var pickerView: UIPickerView!
+
+    override func setUp() {
+        array = MutableObservableArray([1, 2, 3])
+        pickerView = UIPickerView()
+    }
+
+    func testBind() {
+        array.bind(to: pickerView)
+    }
+
+    func testBindUsingCreateTitle() {
+        array.bind(to: pickerView) { (dataSource, row, component, pickerView) -> String? in
+            let indexPath = IndexPath(row: row, section: component)
+            let item = dataSource.item(at: indexPath)
+
+            return String(describing: item)
+        }
+    }
+
+    func testBindUsingBinderDataSource() {
+        let createTitle: ([Int], Int, Int, UIPickerView) -> String? = { (dataSource, row, component, pickerView) in
+            let indexPath = IndexPath(row: row, section: component)
+            let item = dataSource.item(at: indexPath)
+
+            return String(describing: item)
+        }
+
+        array.bind(to: pickerView, using: PickerViewBinderDataSource(createTitle))
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR resolves issue #577 by adding data source binding extensions to `UIPickerView`. I followed the `UITableView` pattern and created a `PickerViewBinderDataSource` that implements data source and delegate protocols.

I added a default binding implementation that assumes the data source items are describable and binds the item's string representation. Here are some example use cases.

### Implicit string binding
```
let genderOptions = ObservableArray<String>(["Male", "Female"])

genderOptions.bind(to: genderPicker)
```

### 2D array binding
```
let heightOptions = ObservableArray2D(Array2D<String, String>(sectionsWithItems: [
    ("Feet", ["0 ft", "1 ft", "2 ft", "3 ft", "4 ft", "5 ft", "6 ft", "7 ft", "8 ft", "9 ft"]),
    ("Inches", ["0 in", "1 in", "2 in", "3 in", "4 in", "5 in", "6 in", "7 in", "8 in", "9 in", "10 in", "11 in", "12 in"])
]))

self.viewModel.heightOptions.bind(to: self.heightPicker) { (dataSource, row, component, pickerView) -> String? in
    let indexPath = IndexPath(row: row, section: component)
    let item = dataSource.item(at: indexPath)

    return item
}
```