### PR TITLE
Fix compiler warnings when building with Xcode 10.2 (#607)

### DIFF
--- a/Sources/Bond/Data Sources/FlatDataSourceChangesetConvertible.swift
+++ b/Sources/Bond/Data Sources/FlatDataSourceChangesetConvertible.swift
@@ -73,9 +73,18 @@ extension Array: FlatDataSourceChangesetConvertible {
     }
 }
 
-extension OrderedCollectionChangeset: FlatDataSourceChangeset where Operation.Index: FlatDataIndexConvertable, Collection: QueryableFlatDataSourceProtocol, Operation.Element == Collection.Item {}
+extension OrderedCollectionChangeset: FlatDataSourceChangeset where
+    Collection: QueryableFlatDataSourceProtocol,
+    Collection.Index: FlatDataIndexConvertable,
+    Collection.Item == Collection.Element
+{
+}
 
-extension OrderedCollectionChangeset: FlatDataSourceChangesetConvertible where Operation.Index: FlatDataIndexConvertable, Collection: QueryableFlatDataSourceProtocol, Operation.Element == Collection.Item {
+extension OrderedCollectionChangeset: FlatDataSourceChangesetConvertible where
+    Collection: QueryableFlatDataSourceProtocol,
+    Collection.Index: FlatDataIndexConvertable,
+    Collection.Item == Collection.Element
+{
     public typealias Changeset = OrderedCollectionChangeset<Collection>
 
     public var asFlatDataSourceChangeset: OrderedCollectionChangeset<Collection> {


### PR DESCRIPTION
This PR fixes #607 and by fix I mean it compiles and all the tests pass. I'm not knowledgable enough about this codebase to say whether or not there may be any unintended consequences. I essentially replaced where clause references from Operation to Collection. Operation is `OrderedCollectionOperation<Collection.Element, Collection.Index>` so there doesn't appear to be any issues.