### PR TITLE
selectedItemIndexPath is made public.

### DIFF
--- a/Sources/Bond/UIKit/UICollectionView.swift
+++ b/Sources/Bond/UIKit/UICollectionView.swift
@@ -50,7 +50,7 @@ extension ReactiveExtensions where Base: UICollectionView {
     /// A signal that emits index paths of selected collection view cells.
     ///
     /// - Note: Uses collection view's `delegate` protocol proxy to observe calls made to `UICollectionViewDelegate.collectionView(_:didSelectItemAt:)` method.
-    var selectedItemIndexPath: SafeSignal<IndexPath> {
+    public var selectedItemIndexPath: SafeSignal<IndexPath> {
         return delegate.signal(for: #selector(UICollectionViewDelegate.collectionView(_:didSelectItemAt:))) { (subject: SafePublishSubject<IndexPath>, _: UICollectionView, indexPath: IndexPath) in
             subject.next(indexPath)
         }


### PR DESCRIPTION
Due to inaccesible issue for version 7.4.0 (Xcode 10.2 Swift 5), selectedItemIndexPath is made public.