### PR TITLE
Revert "Compatible with devices prior to iOS 11."

### DIFF
--- a/Sources/Bond/Shared/NSObject+KVO.swift
+++ b/Sources/Bond/Shared/NSObject+KVO.swift
@@ -66,20 +66,10 @@ extension ReactiveExtensions where Base: NSObject {
             }
 
             let disposable = base._willDeallocate.observeCompleted {
-                if #available(iOS 11, *) {} else {
-                    let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
-                    base.removeObserver(base, forKeyPath: keyPathString)
-                }
-                
                 subscription.invalidate()
             }
 
             return DeinitDisposable(disposable: BlockDisposable {
-                if #available(iOS 11, *) {} else {
-                    let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
-                    base.removeObserver(base, forKeyPath: keyPathString)
-                }
-                
                 subscription.invalidate()
                 disposable.dispose()
             })


### PR DESCRIPTION
This was apparently fixed in the latest Xcode / SDK, as observers are correctly disposed automatically and this is actually crashing on iOS 10 instead.

The linked bug for why this was introduced runs correctly (https://bugs.swift.org/browse/SR-5752) 