### PR TITLE
Update to use new Combine-inspired API in ReactiveKit 3.14

### DIFF
--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "7.6.0"
+  s.version      = "7.6.1"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.11"
   s.tvos.deployment_target = "9.0"
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "7.6.0" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "7.6.1" }
   s.source_files  = "Sources/**/*.{h,m,swift}", "Supporting Files/Bond.h"
   s.ios.exclude_files = "Sources/Bond/AppKit"
   s.tvos.exclude_files = "Sources/Bond/AppKit"
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.swift_version = '5.0'
 
-  s.dependency "ReactiveKit", "~> 3.10"
-  s.dependency "Differ", "~> 1.3"
+  s.dependency "ReactiveKit", "~> 3.14"
+  s.dependency "Differ", "~> 1.4"
 
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "DeclarativeHub/ReactiveKit" ~> 3.10
+github "DeclarativeHub/ReactiveKit" ~> 3.14
 github "tonyarnold/Differ" ~> 1.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "DeclarativeHub/ReactiveKit" "v3.13.0"
+github "DeclarativeHub/ReactiveKit" "v3.14.2"
 github "tonyarnold/Differ" "1.4.3"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DeclarativeHub/ReactiveKit.git",
         "state": {
           "branch": null,
-          "revision": "1e79f6ca02f6243aae1e46335dfc28c0313f01a1",
-          "version": "3.13.0"
+          "revision": "318d99599469a53b0e0fcf0eb975dba75501ede6",
+          "version": "3.14.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "Bond", targets: ["Bond"])
     ],
     dependencies: [
-        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.11.0")),
-        .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.4.1"))
+        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.14")),
+        .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.4"))
     ],
     targets: [
         .target(name: "BNDProtocolProxyBase"),

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "Bond", targets: ["Bond"])
     ],
     dependencies: [
-        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.14")),
-        .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.4"))
+        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.14.2")),
+        .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.4.3"))
     ],
     targets: [
         .target(name: "BNDProtocolProxyBase"),

--- a/Sources/Bond/AppKit/NSGestureRecognizer.swift
+++ b/Sources/Bond/AppKit/NSGestureRecognizer.swift
@@ -53,7 +53,7 @@ extension ReactiveExtensions where Base: NSView {
                 target.unregister()
             }
         }
-        .take(until: base.deallocated)
+        .prefix(untilOutputFrom: base.deallocated)
     }
 
     public func clickGesture(numberOfClicks: Int = 1, numberOfTouches: Int = 1) -> SafeSignal<NSClickGestureRecognizer> {

--- a/Sources/Bond/Bond.swift
+++ b/Sources/Bond/Bond.swift
@@ -47,7 +47,7 @@ public struct Bond<Element>: BindableProtocol {
 
     public func bind(signal: Signal<Element, Never>) -> Disposable {
         if let target = target {
-            return signal.take(until: target.deallocated).observeNext { element in
+            return signal.prefix(untilOutputFrom: target.deallocated).observeNext { element in
                 self.context.execute {
                     if let target = self.target {
                         self.setter(target, element)

--- a/Sources/Bond/DynamicSubject.swift
+++ b/Sources/Bond/DynamicSubject.swift
@@ -84,7 +84,7 @@ public struct FailableDynamicSubject<Element, Error: Swift.Error>: SubjectProtoc
         self.triggerEventOnSetting = triggerEventOnSetting
     }
 
-    public func on(_ event: Event<Element, Error>) {
+    public func on(_ event: Signal<Element, Error>.Event) {
         if case .next(let element) = event, let target = target {
             setter(target, element)
             if triggerEventOnSetting {
@@ -93,10 +93,10 @@ public struct FailableDynamicSubject<Element, Error: Swift.Error>: SubjectProtoc
         }
     }
 
-    public func observe(with observer: @escaping (Event<Element, Error>) -> Void) -> Disposable {
+    public func observe(with observer: @escaping (Signal<Element, Error>.Event) -> Void) -> Disposable {
         guard let target = target else { observer(.completed); return NonDisposable.instance }
         let getter = self.getter
-        return signal.start(with: ()).merge(with: subject).tryMap { [weak target] () -> Result<Element?, Error> in
+        return signal.prepend(()).merge(with: subject).tryMap { [weak target] () -> Result<Element?, Error> in
             if let target = target {
                 switch getter(target) {
                 case .success(let element):
@@ -107,7 +107,7 @@ public struct FailableDynamicSubject<Element, Error: Swift.Error>: SubjectProtoc
             } else {
                 return .success(nil)
             }
-        }.ignoreNils().take(until: (target as! Deallocatable).deallocated).observe(with: observer)
+        }.ignoreNils().prefix(untilOutputFrom: (target as! Deallocatable).deallocated).observe(with: observer)
     }
 
     public func bind(signal: Signal<Element, Never>) -> Disposable {
@@ -116,7 +116,7 @@ public struct FailableDynamicSubject<Element, Error: Swift.Error>: SubjectProtoc
             let subject = self.subject
             let context = self.context
             let triggerEventOnSetting = self.triggerEventOnSetting
-            return signal.take(until: (target as! Deallocatable).deallocated).observe { [weak target] event in
+            return signal.prefix(untilOutputFrom: (target as! Deallocatable).deallocated).observe { [weak target] event in
                 context.execute { [weak target] in
                     switch event {
                     case .next(let element):

--- a/Sources/Bond/Observable Collections/Property+ChangesetContainerProtocol.swift
+++ b/Sources/Bond/Observable Collections/Property+ChangesetContainerProtocol.swift
@@ -76,7 +76,7 @@ extension Property: ChangesetContainerProtocol, MutableChangesetContainerProtoco
         lock.lock()
         let proxy = Property(value) // use proxy to collect changes
         var patche: [Changeset.Operation] = []
-        let disposable = proxy.skip(first: 1).observeNext { event in
+        let disposable = proxy.dropFirst(1).observeNext { event in
             patche.append(contentsOf: event.patch)
         }
         update(proxy)

--- a/Sources/Bond/Shared/NSObject+KVO.swift
+++ b/Sources/Bond/Shared/NSObject+KVO.swift
@@ -333,7 +333,7 @@ private class RKKeyValueSignal: NSObject, SignalProtocol {
         }
     }
 
-    fileprivate func observe(with observer: @escaping (Event<Void, Never>) -> Void) -> Disposable {
+    fileprivate func observe(with observer: @escaping (Signal<Void, Never>.Event) -> Void) -> Disposable {
         increaseNumberOfObservers()
         let disposable = subject.observe(with: observer)
         let cleanupDisposabe = BlockDisposable {

--- a/Sources/Bond/Signal+Heartbeat.swift
+++ b/Sources/Bond/Signal+Heartbeat.swift
@@ -34,8 +34,8 @@ extension SignalProtocol {
     public static func heartbeat(interval seconds: Double) -> Signal<Void, Never> {
         let willEnterForeground = NotificationCenter.default.reactive.notification(name: UIApplication.willEnterForegroundNotification)
         let didEnterBackgorund = NotificationCenter.default.reactive.notification(name: UIApplication.didEnterBackgroundNotification)
-        return willEnterForeground.replaceElements(with: ()).start(with: ()).flatMapLatest { () -> Signal<Void, Never> in
-            return SafeSignal<Int>(sequence: 0..., interval: seconds, queue: .global()).replaceElements(with: ()).start(with: ()).take(until: didEnterBackgorund)
+        return willEnterForeground.replaceElements(with: ()).prepend(()).flatMapLatest { () -> Signal<Void, Never> in
+            return SafeSignal<Int>(sequence: 0..., interval: seconds, queue: .global()).replaceElements(with: ()).prepend(()).prefix(untilOutputFrom: didEnterBackgorund)
         }
     }
 }

--- a/Sources/Bond/UIKit/UIControl.swift
+++ b/Sources/Bond/UIKit/UIControl.swift
@@ -42,7 +42,7 @@ extension ReactiveExtensions where Base: UIControl {
             return BlockDisposable {
                 target.unregister()
             }
-        }.take(until: base.deallocated)
+        }.prefix(untilOutputFrom: base.deallocated)
     }
 
     public var isEnabled: Bond<Bool> {

--- a/Sources/Bond/UIKit/UIGestureRecognizer.swift
+++ b/Sources/Bond/UIKit/UIGestureRecognizer.swift
@@ -58,7 +58,7 @@ extension ReactiveExtensions where Base: UIView {
             return BlockDisposable {
                 target.unregister()
             }
-            }.take(until: base.deallocated)
+        }.prefix(untilOutputFrom: base.deallocated)
     }
 
     public func tapGesture(numberOfTaps: Int = 1, numberOfTouches: Int = 1) -> SafeSignal<UITapGestureRecognizer> {

--- a/Tests/BondTests/Helpers.swift
+++ b/Tests/BondTests/Helpers.swift
@@ -13,9 +13,9 @@ import ReactiveKit
 func XCTAssertEqual(_ lhs: CGFloat, _ rhs: CGFloat, precision: CGFloat = 0.01, file: StaticString = #file, line: UInt = #line) {
     XCTAssert(abs(lhs - rhs) < precision, file: file, line: line)
 }
-extension Event {
+extension Signal.Event {
 
-    func isEqualTo(_ event: Event<Element, Error>) -> Bool {
+    func isEqualTo(_ event: Signal<Element, Error>.Event) -> Bool {
 
         switch (self, event) {
         case (.completed, .completed):
@@ -74,12 +74,12 @@ extension SignalProtocol {
         expect(expectedElements.map { .next($0) } + [.completed], message(), expectation: expectation, file: file, line: line)
     }
 
-    func expect(_ expectedEvents: [Event<Element, Error>],
+    func expect(_ expectedEvents: [Signal<Element, Error>.Event],
                 _ message: @autoclosure () -> String = "",
                 expectation: XCTestExpectation? = nil,
                 file: StaticString = #file, line: UInt = #line) {
         var eventsToProcess = expectedEvents
-        var receivedEvents: [Event<Element, Error>] = []
+        var receivedEvents: [Signal<Element, Error>.Event] = []
         let message = message()
         let _ = observe { event in
             receivedEvents.append(event)


### PR DESCRIPTION
This PR updates the use of deprecated ReactiveKit API to use the new, Combine-inspired API. It also updates the required versions of the dependencies to their latest versions.

There are no other changes.