### PR TITLE
Bump ReactiveKit to version 3.15.4

### DIFF
--- a/Bond.podspec
+++ b/Bond.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.swift_version = '5.0'
 
-  s.dependency "ReactiveKit", "~> 3.14"
+  s.dependency "ReactiveKit", "~> 3.15"
   s.dependency "Differ", "~> 1.4"
 
 end

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "DeclarativeHub/ReactiveKit" "v3.14.2"
+github "DeclarativeHub/ReactiveKit" "v3.15.4"
 github "tonyarnold/Differ" "1.4.3"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/DeclarativeHub/ReactiveKit.git",
         "state": {
           "branch": null,
-          "revision": "318d99599469a53b0e0fcf0eb975dba75501ede6",
-          "version": "3.14.2"
+          "revision": "016b3981690658f8cf54641af4694bdaa4bd9425",
+          "version": "3.15.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Bond", targets: ["Bond"])
     ],
     dependencies: [
-        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.14.2")),
+        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.15.4")),
         .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.4.3"))
     ],
     targets: [


### PR DESCRIPTION
This PR updates ReactiveKit to a minimum version of 3.15.x. There were no code changes necessary for this.