### PR TITLE
Introducing MainBlockDisposable

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		16210A461D3EC474004AEDF3 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16210A3C1D3EC474004AEDF3 /* Bond.framework */; };
 		16887E3A1D744ABB00EDA099 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16887E391D744ABB00EDA099 /* AppDelegate.swift */; };
 		16887E441D744ABB00EDA099 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 16887E421D744ABB00EDA099 /* LaunchScreen.storyboard */; };
+		3895CCB323A25C61008FD491 /* MainBlockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3895CCB223A25C61008FD491 /* MainBlockDisposable.swift */; };
 		75CA9E9220678E600011E5BB /* UISearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CA9E9120678E600011E5BB /* UISearchBar.swift */; };
 		824267CE225F7E4B001B1648 /* Differ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824267CC225F7E4B001B1648 /* Differ.framework */; };
 		824267CF225F7E4B001B1648 /* ReactiveKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824267CD225F7E4B001B1648 /* ReactiveKit.framework */; };
@@ -388,6 +389,7 @@
 		16887E451D744ABB00EDA099 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		16D30EAE1D6591D300C2435D /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		16D30ED61D65D11900C2435D /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3895CCB223A25C61008FD491 /* MainBlockDisposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainBlockDisposable.swift; sourceTree = "<group>"; };
 		75CA9E9120678E600011E5BB /* UISearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISearchBar.swift; sourceTree = "<group>"; };
 		824267CC225F7E4B001B1648 /* Differ.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Differ.framework; path = Carthage/Build/iOS/Differ.framework; sourceTree = "<group>"; };
 		824267CD225F7E4B001B1648 /* ReactiveKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveKit.framework; path = Carthage/Build/iOS/ReactiveKit.framework; sourceTree = "<group>"; };
@@ -687,6 +689,7 @@
 		90C04D1F1E8F0B1D000077C8 /* Bond */ = {
 			isa = PBXGroup;
 			children = (
+				3895CCB223A25C61008FD491 /* MainBlockDisposable.swift */,
 				90C04D201E8F0B1D000077C8 /* Bond.swift */,
 				90C04D231E8F0B1D000077C8 /* DynamicSubject.swift */,
 				90C04D371E8F0B1D000077C8 /* Observable.swift */,
@@ -1158,6 +1161,7 @@
 				070FE2741F0138180031B7BD /* NSLayoutConstraint.swift in Sources */,
 				EC1F127D2167C9EE002F0D1B /* UnorderedCollectionChangeset+Set.swift in Sources */,
 				90C04DB61E8F0B97000077C8 /* UIGestureRecognizer.swift in Sources */,
+				3895CCB323A25C61008FD491 /* MainBlockDisposable.swift in Sources */,
 				EC930F42222B1137000D397C /* TreeChangeset+Array2D.swift in Sources */,
 				ECBCE0E62161766C0078E03B /* SectionedDataSourceChangesetConvertible.swift in Sources */,
 				90A4430B1E9055D100D611FE /* NSMenuItem.swift in Sources */,

--- a/Sources/Bond/AppKit/NSGestureRecognizer.swift
+++ b/Sources/Bond/AppKit/NSGestureRecognizer.swift
@@ -49,10 +49,8 @@ extension ReactiveExtensions where Base: NSView {
                 // swiftlint:disable:next force_cast
                 observer.receive(recog as! T)
             }
-            return BlockDisposable {
-                ExecutionContext.immediateOnMain.execute {
-                    target.unregister()
-                }
+            return MainBlockDisposable {
+                target.unregister()
             }
         }
         .prefix(untilOutputFrom: base.deallocated)

--- a/Sources/Bond/MainBlockDisposable.swift
+++ b/Sources/Bond/MainBlockDisposable.swift
@@ -1,0 +1,29 @@
+//
+//  MainBlockDisposable.swift
+//  
+//
+//  Created by Diego Rodriguez on 12/12/2019.
+//
+
+import Foundation
+import ReactiveKit
+
+/// A disposable that executes the given block on the main thread upon disposing.
+public final class MainBlockDisposable: Disposable {
+    private let _blockDisposable: BlockDisposable
+    
+    public init(_ handler: @escaping () -> ()) {
+        _blockDisposable = BlockDisposable(handler)
+    }
+    
+    public var isDisposed: Bool {
+        return _blockDisposable.isDisposed
+    }
+    
+    public func dispose() {
+        ExecutionContext.immediateOnMain.execute { [weak self] in
+          self?._blockDisposable.dispose()
+        }
+    }
+}
+

--- a/Sources/Bond/ProtocolProxy.swift
+++ b/Sources/Bond/ProtocolProxy.swift
@@ -72,11 +72,9 @@ public class ProtocolProxy: BNDProtocolProxyBase {
             invocation.writeReturnValue(result)
         }
         registerDelegate()
-        return BlockDisposable { [weak self] in
-            ExecutionContext.immediateOnMain.execute {
-                self?.invokers[selector] = nil
-                self?.registerDelegate()
-            }
+        return MainBlockDisposable { [weak self] in
+            self?.invokers[selector] = nil
+            self?.registerDelegate()
         }
     }
 
@@ -86,11 +84,9 @@ public class ProtocolProxy: BNDProtocolProxyBase {
             invocation.writeReturnValue(result)
         }
         registerDelegate()
-        return BlockDisposable { [weak self] in
-            ExecutionContext.immediateOnMain.execute {
-                self?.invokers[selector] = nil
-                self?.registerDelegate()
-            }
+        return MainBlockDisposable { [weak self] in
+            self?.invokers[selector] = nil
+            self?.registerDelegate()
         }
     }
 
@@ -100,11 +96,9 @@ public class ProtocolProxy: BNDProtocolProxyBase {
             invocation.writeReturnValue(result)
         }
         registerDelegate()
-        return BlockDisposable { [weak self] in
-            ExecutionContext.immediateOnMain.execute {
-                self?.invokers[selector] = nil
-                self?.registerDelegate()
-            }
+        return MainBlockDisposable { [weak self] in
+            self?.invokers[selector] = nil
+            self?.registerDelegate()
         }
     }
 
@@ -114,11 +108,9 @@ public class ProtocolProxy: BNDProtocolProxyBase {
             invocation.writeReturnValue(result)
         }
         registerDelegate()
-        return BlockDisposable { [weak self] in
-            ExecutionContext.immediateOnMain.execute {
-                self?.invokers[selector] = nil
-                self?.registerDelegate()
-            }
+        return MainBlockDisposable { [weak self] in
+            self?.invokers[selector] = nil
+            self?.registerDelegate()
         }
     }
 
@@ -128,11 +120,9 @@ public class ProtocolProxy: BNDProtocolProxyBase {
             invocation.writeReturnValue(result)
         }
         registerDelegate()
-        return BlockDisposable { [weak self] in
-            ExecutionContext.immediateOnMain.execute {
-                self?.invokers[selector] = nil
-                self?.registerDelegate()
-            }
+        return MainBlockDisposable { [weak self] in
+            self?.invokers[selector] = nil
+            self?.registerDelegate()
         }
     }
 
@@ -142,11 +132,9 @@ public class ProtocolProxy: BNDProtocolProxyBase {
             invocation.writeReturnValue(result)
         }
         registerDelegate()
-        return BlockDisposable { [weak self] in
-            ExecutionContext.immediateOnMain.execute {
-                self?.invokers[selector] = nil
-                self?.registerDelegate()
-            }
+        return MainBlockDisposable { [weak self] in
+            self?.invokers[selector] = nil
+            self?.registerDelegate()
         }
     }
 
@@ -159,10 +147,8 @@ public class ProtocolProxy: BNDProtocolProxyBase {
                 let disposable = CompositeDisposable()
                 disposable += registerInvoker(subject)
                 disposable += subject.observe(with: observer)
-                disposable += BlockDisposable { [weak self] in
-                    ExecutionContext.immediateOnMain.execute {
-                        self?.handlers[selector] = nil
-                    }
+                disposable += MainBlockDisposable { [weak self] in
+                    self?.handlers[selector] = nil
                 }
                 return disposable
             }.share(limit: 0)

--- a/Sources/Bond/Shared/NSObject+KVO.swift
+++ b/Sources/Bond/Shared/NSObject+KVO.swift
@@ -74,15 +74,13 @@ extension ReactiveExtensions where Base: NSObject {
                 subscription.invalidate()
             }
 
-            return DeinitDisposable(disposable: BlockDisposable {
-                ExecutionContext.immediateOnMain.execute {
-                    if #available(iOS 11, *) {} else {
-                        let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
-                        base.removeObserver(base, forKeyPath: keyPathString)
-                    }
-                    subscription.invalidate()
-                    disposable.dispose()
-                }
+            return DeinitDisposable(disposable: MainBlockDisposable {
+                  if #available(iOS 11, *) {} else {
+                      let keyPathString = NSExpression(forKeyPath: keyPath).keyPath
+                      base.removeObserver(base, forKeyPath: keyPathString)
+                  }
+                  subscription.invalidate()
+                  disposable.dispose()
             })
         }
     }

--- a/Sources/Bond/Shared/NotificationCenter.swift
+++ b/Sources/Bond/Shared/NotificationCenter.swift
@@ -33,10 +33,8 @@ extension ReactiveExtensions where Base: NotificationCenter {
             let subscription = self.base.addObserver(forName: name, object: object, queue: nil, using: { notification in
                 observer.receive(notification)
             })
-            return BlockDisposable {
-                ExecutionContext.immediateOnMain.execute {
-                    self.base.removeObserver(subscription)
-                }
+            return MainBlockDisposable {
+                self.base.removeObserver(subscription)
             }
         }
     }

--- a/Sources/Bond/UIKit/UIControl.swift
+++ b/Sources/Bond/UIKit/UIControl.swift
@@ -39,10 +39,8 @@ extension ReactiveExtensions where Base: UIControl {
             let target = BNDControlTarget(control: base, events: events) {
                 observer.receive(())
             }
-            return BlockDisposable {
-                ExecutionContext.immediateOnMain.execute {
-                    target.unregister()
-                }
+            return MainBlockDisposable {
+                target.unregister()
             }
         }.prefix(untilOutputFrom: base.deallocated)
     }

--- a/Sources/Bond/UIKit/UIGestureRecognizer.swift
+++ b/Sources/Bond/UIKit/UIGestureRecognizer.swift
@@ -55,10 +55,8 @@ extension ReactiveExtensions where Base: UIView {
             let target = BNDGestureTarget(view: base, gestureRecognizer: gestureRecognizer) { recog in
                 observer.receive(recog as! T)
             }
-            return BlockDisposable {
-                ExecutionContext.immediateOnMain.execute {
-                    target.unregister()
-                }
+            return MainBlockDisposable {
+                target.unregister()
             }
         }.prefix(untilOutputFrom: base.deallocated)
     }


### PR DESCRIPTION
It's common to need a block disposable that is guaranteed to run in the main thread, specially dealing with UI changes on reactive streams. 
`MainBlockDisposable` uses composition internally using `BlockDisposable` executing the dispose function in the main thread. Thanks @ibrahimkteish for the help.