### PR TITLE
Added MainBlockDisposable to tvOS and macOS targets

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		16887E3A1D744ABB00EDA099 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16887E391D744ABB00EDA099 /* AppDelegate.swift */; };
 		16887E441D744ABB00EDA099 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 16887E421D744ABB00EDA099 /* LaunchScreen.storyboard */; };
 		3895CCB323A25C61008FD491 /* MainBlockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3895CCB223A25C61008FD491 /* MainBlockDisposable.swift */; };
+		6E8ECECD23A2F7D500856D90 /* MainBlockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3895CCB223A25C61008FD491 /* MainBlockDisposable.swift */; };
+		6E8ECECE23A2F7D600856D90 /* MainBlockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3895CCB223A25C61008FD491 /* MainBlockDisposable.swift */; };
 		75CA9E9220678E600011E5BB /* UISearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CA9E9120678E600011E5BB /* UISearchBar.swift */; };
 		824267CE225F7E4B001B1648 /* Differ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824267CC225F7E4B001B1648 /* Differ.framework */; };
 		824267CF225F7E4B001B1648 /* ReactiveKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824267CD225F7E4B001B1648 /* ReactiveKit.framework */; };
@@ -1241,6 +1243,7 @@
 				ECC1A6D1207A18DC00AE762C /* NSTableView+DataSource.swift in Sources */,
 				90A443361E9055D800D611FE /* UISwitch.swift in Sources */,
 				ECFF44B82168F5C000B5EDB0 /* Instantiatable.swift in Sources */,
+				6E8ECECE23A2F7D600856D90 /* MainBlockDisposable.swift in Sources */,
 				90A443271E9055D800D611FE /* UIBarItem.swift in Sources */,
 				ECBC51C02161637A00BE80EC /* OrderedCollectionDiff+Strideable+Differ.swift in Sources */,
 				90C04D861E8F0B8D000077C8 /* NSStatusBarButton.swift in Sources */,
@@ -1344,6 +1347,7 @@
 				ECC1A6D2207A18DC00AE762C /* NSTableView+DataSource.swift in Sources */,
 				90A4431E1E9055D200D611FE /* NSSlider.swift in Sources */,
 				ECFF44B92168F5C000B5EDB0 /* Instantiatable.swift in Sources */,
+				6E8ECECD23A2F7D500856D90 /* MainBlockDisposable.swift in Sources */,
 				ECAFB8D6200A7E3900EE0669 /* BNDInvocation.swift in Sources */,
 				ECBC51D52161637B00BE80EC /* OrderedCollectionDiff+Strideable+Differ.swift in Sources */,
 				90C04D981E8F0B96000077C8 /* UIApplication.swift in Sources */,


### PR DESCRIPTION
Adding Bond as a dependency using Carthage for macOS currently fails because MainBlockDisposable.swift is missing from the target. I also added it to the tvOS target. 