### PR TITLE
Make collectionView(_: numberOfItemsInSection:) open on CollectionViewBinderDataSource

### DIFF
--- a/Sources/Bond/UIKit/UICollectionView+DataSource.swift
+++ b/Sources/Bond/UIKit/UICollectionView+DataSource.swift
@@ -159,7 +159,7 @@ open class CollectionViewBinderDataSource<Changeset: SectionedDataSourceChangese
         return changeset?.collection.numberOfSections ?? 0
     }
 
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return changeset?.collection.numberOfItems(inSection: section) ?? 0
     }
 


### PR DESCRIPTION
I need to be able to override this in my implementation of a subclass, but I think this should be open anyways!
@srdanrasic  I had opened this the other day, but I accidentally tried using the wrong branch. This is a fixed PR. Would really appreciate having this pulled in and a new version pushed soon so I don't have to use a private fork in my production application!