### PR TITLE
Add the ability to observe  UIViewController life cycle using signals

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		070FE2741F0138180031B7BD /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D2A1E8F0B1D000077C8 /* NSLayoutConstraint.swift */; };
 		070FE2781F0138190031B7BD /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D2A1E8F0B1D000077C8 /* NSLayoutConstraint.swift */; };
+		0856892E2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0856892D2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift */; };
 		16210A461D3EC474004AEDF3 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16210A3C1D3EC474004AEDF3 /* Bond.framework */; };
 		16887E3A1D744ABB00EDA099 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16887E391D744ABB00EDA099 /* AppDelegate.swift */; };
 		16887E441D744ABB00EDA099 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 16887E421D744ABB00EDA099 /* LaunchScreen.storyboard */; };
@@ -382,6 +383,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0856892D2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerLifeCycle.swift; sourceTree = "<group>"; };
 		161D6D2D1D6F0D92004CA17D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		16210A3C1D3EC474004AEDF3 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		16210A451D3EC474004AEDF3 /* BondTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -784,6 +786,7 @@
 				90C04D2A1E8F0B1D000077C8 /* NSLayoutConstraint.swift */,
 				90C04D2D1E8F0B1D000077C8 /* NSObject.swift */,
 				90C04D2C1E8F0B1D000077C8 /* NSObject+KVO.swift */,
+				0856892D2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1146,6 +1149,7 @@
 				E58FBB8D22187FD700339211 /* UIPickerView+DataSource.swift in Sources */,
 				90C04DBC1E8F0B97000077C8 /* UIRefreshControl.swift in Sources */,
 				ECBC51FA216163BA00BE80EC /* TreeNode.swift in Sources */,
+				0856892E2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift in Sources */,
 				90B5F63B2269D6DD001917B4 /* NSCollectionView+DataSource.swift in Sources */,
 				90C04DBD1E8F0B97000077C8 /* UISegmentedControl.swift in Sources */,
 				ECFF44B12168C21F00B5EDB0 /* Array2D.swift in Sources */,

--- a/Sources/Bond/Shared/ViewControllerLifeCycle.swift
+++ b/Sources/Bond/Shared/ViewControllerLifeCycle.swift
@@ -1,0 +1,126 @@
+//
+//  ViewControllerLifeCycle.swift
+//  Bond-iOS
+//
+//  Created by Ibrahim Koteish on 21/03/2020.
+//  Copyright © 2020 Swift Bond. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+import ReactiveKit
+/// Observe UIViewController life cycle events
+public final class ViewControllerLifeCycle {
+  private let wrapperViewController: WrapperViewController
+  public var viewDidLoad: SafeSignal<Void> {
+    return self.wrapperViewController.viewDidLoadSubject.toSignal()
+  }
+  public var viewWillAppear: SafeSignal<Void> {
+    return self.wrapperViewController.viewWillAppearSubject.toSignal()
+  }
+  public var viewDidAppear: SafeSignal<Void> {
+    return self.wrapperViewController.viewDidAppearSubject.toSignal()
+  }
+  public var viewWillDisappear: SafeSignal<Void> {
+    return self.wrapperViewController.viewWillDisappearSubject.toSignal()
+  }
+  public var viewDidDisappear: SafeSignal<Void> {
+    return self.wrapperViewController.viewDidDisAppearSubject.toSignal()
+  }
+  public init(viewController: UIViewController) {
+    self.wrapperViewController = WrapperViewController()
+    if viewController.isViewLoaded {
+      self.addAsChildViewController(viewController)
+    } else {
+      viewController
+        .reactive
+        .keyPath(\.view, startWithCurrentValue: false)
+        .prefix(maxLength: 1)
+        .observeNext { [weak viewController] _ in
+          guard let viewController = viewController else { return }
+          self.addAsChildViewController(viewController) // weak self ?
+      }
+        .dispose(in: viewController.bag)
+    }
+  }
+
+  private func addAsChildViewController(_ viewController: UIViewController) {
+    viewController.addChild(self.wrapperViewController)
+    viewController.view.addSubview(self.wrapperViewController.view)
+    self.wrapperViewController.view.frame = .zero
+    self.wrapperViewController.view.autoresizingMask = []
+    self.wrapperViewController.didMove(toParent: viewController)
+  }
+}
+
+private extension ViewControllerLifeCycle {
+  final class WrapperViewController: UIViewController {
+    fileprivate let viewDidLoadSubject       = SafeReplayOneSubject<Void>()
+    fileprivate let viewWillAppearSubject    = SafeReplayOneSubject<Void>()
+    fileprivate let viewDidAppearSubject     = SafeReplayOneSubject<Void>()
+    fileprivate let viewWillDisappearSubject = SafeReplayOneSubject<Void>()
+    fileprivate let viewDidDisAppearSubject  = SafeReplayOneSubject<Void>()
+   
+    override func viewDidLoad() {
+      super.viewDidLoad()
+      self.viewDidLoadSubject.send()
+    }
+    override func viewWillAppear(_ animated: Bool) {
+      super.viewWillAppear(animated)
+      self.viewWillAppearSubject.send()
+    }
+    override func viewDidAppear(_ animated: Bool) {
+      super.viewDidAppear(animated)
+      self.viewDidAppearSubject.send()
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+      super.viewWillDisappear(animated)
+      self.viewWillDisappearSubject.send()
+    }
+    override func viewDidDisappear(_ animated: Bool) {
+      super.viewDidDisappear(animated)
+      self.viewDidDisAppearSubject.send()
+    }
+  }
+}
+
+public protocol ViewControllerLibeCycleObservable: class {
+  var rxLifeCycle: ViewControllerLifeCycle { get }
+}
+
+extension UIViewController: ViewControllerLibeCycleObservable {
+  private struct AssociatedKeys {
+    static var viewControllerLifeCycleKey = "viewControllerLifeCycleKey"
+  }
+  public var rxLifeCycle: ViewControllerLifeCycle {
+    if let lifeCycle = objc_getAssociatedObject(self, &AssociatedKeys.viewControllerLifeCycleKey) {
+      return lifeCycle as! ViewControllerLifeCycle
+    } else {
+      let lifeCycle = ViewControllerLifeCycle(viewController: self)
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.viewControllerLifeCycleKey,
+        lifeCycle, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      return lifeCycle
+    }
+  }
+}
+
+extension ReactiveExtensions where Base: ViewControllerLibeCycleObservable {
+  var viewDidLoad: SafeSignal<Void> {
+    return self.base.rxLifeCycle.viewDidLoad
+  }
+  var viewWillAppear: SafeSignal<Void> {
+    return self.base.rxLifeCycle.viewWillAppear
+  }
+  var viewDidAppear: SafeSignal<Void> {
+    return self.base.rxLifeCycle.viewDidAppear
+  }
+  var viewWillDisappear: SafeSignal<Void> {
+    return self.base.rxLifeCycle.viewWillDisappear
+  }
+  var viewDidDisappear: SafeSignal<Void> {
+    return self.base.rxLifeCycle.viewDidDisappear
+  }
+}

--- a/Sources/Bond/Shared/ViewControllerLifecycle.swift
+++ b/Sources/Bond/Shared/ViewControllerLifecycle.swift
@@ -8,119 +8,120 @@
 
 import Foundation
 import UIKit
-
 import ReactiveKit
+
 /// Observe UIViewController life cycle events
 public final class ViewControllerLifecycle {
-  private let wrapperViewController: WrapperViewController
-  public var viewDidLoad: SafeSignal<Void> {
-    return self.wrapperViewController.viewDidLoadSubject.toSignal()
-  }
-  public var viewWillAppear: SafeSignal<Void> {
-    return self.wrapperViewController.viewWillAppearSubject.toSignal()
-  }
-  public var viewDidAppear: SafeSignal<Void> {
-    return self.wrapperViewController.viewDidAppearSubject.toSignal()
-  }
-  public var viewWillDisappear: SafeSignal<Void> {
-    return self.wrapperViewController.viewWillDisappearSubject.toSignal()
-  }
-  public var viewDidDisappear: SafeSignal<Void> {
-    return self.wrapperViewController.viewDidDisAppearSubject.toSignal()
-  }
-  public init(viewController: UIViewController) {
-    self.wrapperViewController = WrapperViewController()
-    if viewController.isViewLoaded {
-      self.addAsChildViewController(viewController)
-    } else {
-      viewController
-        .reactive
-        .keyPath(\.view, startWithCurrentValue: false)
-        .prefix(maxLength: 1)
-        .observeNext { [weak viewController] _ in
-          guard let viewController = viewController else { return }
-          self.addAsChildViewController(viewController) // weak self ?
-      }
-        .dispose(in: viewController.bag)
+    
+    private let wrapperViewController: WrapperViewController
+    public var viewDidLoad: SafeSignal<Void> {
+        return self.wrapperViewController.viewDidLoadSubject.toSignal()
     }
-  }
-
-  private func addAsChildViewController(_ viewController: UIViewController) {
-    viewController.addChild(self.wrapperViewController)
-    viewController.view.addSubview(self.wrapperViewController.view)
-    self.wrapperViewController.view.frame = .zero
-    self.wrapperViewController.view.autoresizingMask = []
-    self.wrapperViewController.didMove(toParent: viewController)
-  }
+    public var viewWillAppear: SafeSignal<Void> {
+        return self.wrapperViewController.viewWillAppearSubject.toSignal()
+    }
+    public var viewDidAppear: SafeSignal<Void> {
+        return self.wrapperViewController.viewDidAppearSubject.toSignal()
+    }
+    public var viewWillDisappear: SafeSignal<Void> {
+        return self.wrapperViewController.viewWillDisappearSubject.toSignal()
+    }
+    public var viewDidDisappear: SafeSignal<Void> {
+        return self.wrapperViewController.viewDidDisAppearSubject.toSignal()
+    }
+    public init(viewController: UIViewController) {
+        self.wrapperViewController = WrapperViewController()
+        if viewController.isViewLoaded {
+            self.addAsChildViewController(viewController)
+        } else {
+            viewController
+                .reactive
+                .keyPath(\.view, startWithCurrentValue: false)
+                .prefix(maxLength: 1)
+                .observeNext { [weak viewController] _ in
+                    guard let viewController = viewController else { return }
+                    self.addAsChildViewController(viewController) // weak self ?
+            }
+            .dispose(in: viewController.bag)
+        }
+    }
+    
+    private func addAsChildViewController(_ viewController: UIViewController) {
+        viewController.addChild(self.wrapperViewController)
+        viewController.view.addSubview(self.wrapperViewController.view)
+        self.wrapperViewController.view.frame = .zero
+        self.wrapperViewController.view.autoresizingMask = []
+        self.wrapperViewController.didMove(toParent: viewController)
+    }
 }
 
 private extension ViewControllerLifecycle {
-  final class WrapperViewController: UIViewController {
-    fileprivate let viewDidLoadSubject       = SafeReplayOneSubject<Void>()
-    fileprivate let viewWillAppearSubject    = SafeReplayOneSubject<Void>()
-    fileprivate let viewDidAppearSubject     = SafeReplayOneSubject<Void>()
-    fileprivate let viewWillDisappearSubject = SafeReplayOneSubject<Void>()
-    fileprivate let viewDidDisAppearSubject  = SafeReplayOneSubject<Void>()
-   
-    override func viewDidLoad() {
-      super.viewDidLoad()
-      self.viewDidLoadSubject.send()
+    final class WrapperViewController: UIViewController {
+        fileprivate let viewDidLoadSubject       = SafeReplayOneSubject<Void>()
+        fileprivate let viewWillAppearSubject    = SafeReplayOneSubject<Void>()
+        fileprivate let viewDidAppearSubject     = SafeReplayOneSubject<Void>()
+        fileprivate let viewWillDisappearSubject = SafeReplayOneSubject<Void>()
+        fileprivate let viewDidDisAppearSubject  = SafeReplayOneSubject<Void>()
+        
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            self.viewDidLoadSubject.send()
+        }
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            self.viewWillAppearSubject.send()
+        }
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            self.viewDidAppearSubject.send()
+        }
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            self.viewWillDisappearSubject.send()
+        }
+        override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(animated)
+            self.viewDidDisAppearSubject.send()
+        }
     }
-    override func viewWillAppear(_ animated: Bool) {
-      super.viewWillAppear(animated)
-      self.viewWillAppearSubject.send()
-    }
-    override func viewDidAppear(_ animated: Bool) {
-      super.viewDidAppear(animated)
-      self.viewDidAppearSubject.send()
-    }
-    override func viewWillDisappear(_ animated: Bool) {
-      super.viewWillDisappear(animated)
-      self.viewWillDisappearSubject.send()
-    }
-    override func viewDidDisappear(_ animated: Bool) {
-      super.viewDidDisappear(animated)
-      self.viewDidDisAppearSubject.send()
-    }
-  }
 }
 
 public protocol ViewControllerLibeCycleObservable: class {
-  var rxLifeCycle: ViewControllerLifecycle { get }
+    var rxLifeCycle: ViewControllerLifecycle { get }
 }
 
 extension UIViewController: ViewControllerLibeCycleObservable {
-  private struct AssociatedKeys {
-    static var viewControllerLifeCycleKey = "viewControllerLifeCycleKey"
-  }
-  public var rxLifeCycle: ViewControllerLifecycle {
-    if let lifeCycle = objc_getAssociatedObject(self, &AssociatedKeys.viewControllerLifeCycleKey) {
-      return lifeCycle as! ViewControllerLifecycle
-    } else {
-      let lifeCycle = ViewControllerLifecycle(viewController: self)
-      objc_setAssociatedObject(
-        self,
-        &AssociatedKeys.viewControllerLifeCycleKey,
-        lifeCycle, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-      return lifeCycle
+    private struct AssociatedKeys {
+        static var viewControllerLifeCycleKey = "viewControllerLifeCycleKey"
     }
-  }
+    public var rxLifeCycle: ViewControllerLifecycle {
+        if let lifeCycle = objc_getAssociatedObject(self, &AssociatedKeys.viewControllerLifeCycleKey) {
+            return lifeCycle as! ViewControllerLifecycle
+        } else {
+            let lifeCycle = ViewControllerLifecycle(viewController: self)
+            objc_setAssociatedObject(
+                self,
+                &AssociatedKeys.viewControllerLifeCycleKey,
+                lifeCycle, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            return lifeCycle
+        }
+    }
 }
 
 extension ReactiveExtensions where Base: ViewControllerLibeCycleObservable {
-  var viewDidLoad: SafeSignal<Void> {
-    return self.base.rxLifeCycle.viewDidLoad
-  }
-  var viewWillAppear: SafeSignal<Void> {
-    return self.base.rxLifeCycle.viewWillAppear
-  }
-  var viewDidAppear: SafeSignal<Void> {
-    return self.base.rxLifeCycle.viewDidAppear
-  }
-  var viewWillDisappear: SafeSignal<Void> {
-    return self.base.rxLifeCycle.viewWillDisappear
-  }
-  var viewDidDisappear: SafeSignal<Void> {
-    return self.base.rxLifeCycle.viewDidDisappear
-  }
+    var viewDidLoad: SafeSignal<Void> {
+        return self.base.rxLifeCycle.viewDidLoad
+    }
+    var viewWillAppear: SafeSignal<Void> {
+        return self.base.rxLifeCycle.viewWillAppear
+    }
+    var viewDidAppear: SafeSignal<Void> {
+        return self.base.rxLifeCycle.viewDidAppear
+    }
+    var viewWillDisappear: SafeSignal<Void> {
+        return self.base.rxLifeCycle.viewWillDisappear
+    }
+    var viewDidDisappear: SafeSignal<Void> {
+        return self.base.rxLifeCycle.viewDidDisappear
+    }
 }

--- a/Sources/Bond/Shared/ViewControllerLifecycle.swift
+++ b/Sources/Bond/Shared/ViewControllerLifecycle.swift
@@ -86,11 +86,11 @@ private extension ViewControllerLifecycle {
     }
 }
 
-public protocol ViewControllerLibeCycleObservable: class {
+public protocol ViewControllerLifecycleProvider: class {
     var rxLifeCycle: ViewControllerLifecycle { get }
 }
 
-extension UIViewController: ViewControllerLibeCycleObservable {
+extension UIViewController: ViewControllerLifecycleProvider {
     private struct AssociatedKeys {
         static var viewControllerLifeCycleKey = "viewControllerLifeCycleKey"
     }
@@ -108,7 +108,7 @@ extension UIViewController: ViewControllerLibeCycleObservable {
     }
 }
 
-extension ReactiveExtensions where Base: ViewControllerLibeCycleObservable {
+extension ReactiveExtensions where Base: ViewControllerLifecycleProvider {
     var viewDidLoad: SafeSignal<Void> {
         return self.base.rxLifeCycle.viewDidLoad
     }

--- a/Sources/Bond/Shared/ViewControllerLifecycle.swift
+++ b/Sources/Bond/Shared/ViewControllerLifecycle.swift
@@ -58,10 +58,10 @@ public final class ViewControllerLifecycle {
 private extension ViewControllerLifecycle {
     final class WrapperViewController: UIViewController {
         fileprivate let viewDidLoadSubject       = SafeReplayOneSubject<Void>()
-        fileprivate let viewWillAppearSubject    = SafeReplayOneSubject<Void>()
-        fileprivate let viewDidAppearSubject     = SafeReplayOneSubject<Void>()
-        fileprivate let viewWillDisappearSubject = SafeReplayOneSubject<Void>()
-        fileprivate let viewDidDisAppearSubject  = SafeReplayOneSubject<Void>()
+        fileprivate let viewWillAppearSubject    = PassthroughSubject<Void>()
+        fileprivate let viewDidAppearSubject     = PassthroughSubject<Void>()
+        fileprivate let viewWillDisappearSubject = PassthroughSubject<Void>()
+        fileprivate let viewDidDisAppearSubject  = PassthroughSubject<Void>()
         
         override func viewDidLoad() {
             super.viewDidLoad()

--- a/Sources/Bond/Shared/ViewControllerLifecycle.swift
+++ b/Sources/Bond/Shared/ViewControllerLifecycle.swift
@@ -11,7 +11,7 @@ import UIKit
 
 import ReactiveKit
 /// Observe UIViewController life cycle events
-public final class ViewControllerLifeCycle {
+public final class ViewControllerLifecycle {
   private let wrapperViewController: WrapperViewController
   public var viewDidLoad: SafeSignal<Void> {
     return self.wrapperViewController.viewDidLoadSubject.toSignal()
@@ -54,7 +54,7 @@ public final class ViewControllerLifeCycle {
   }
 }
 
-private extension ViewControllerLifeCycle {
+private extension ViewControllerLifecycle {
   final class WrapperViewController: UIViewController {
     fileprivate let viewDidLoadSubject       = SafeReplayOneSubject<Void>()
     fileprivate let viewWillAppearSubject    = SafeReplayOneSubject<Void>()
@@ -86,18 +86,18 @@ private extension ViewControllerLifeCycle {
 }
 
 public protocol ViewControllerLibeCycleObservable: class {
-  var rxLifeCycle: ViewControllerLifeCycle { get }
+  var rxLifeCycle: ViewControllerLifecycle { get }
 }
 
 extension UIViewController: ViewControllerLibeCycleObservable {
   private struct AssociatedKeys {
     static var viewControllerLifeCycleKey = "viewControllerLifeCycleKey"
   }
-  public var rxLifeCycle: ViewControllerLifeCycle {
+  public var rxLifeCycle: ViewControllerLifecycle {
     if let lifeCycle = objc_getAssociatedObject(self, &AssociatedKeys.viewControllerLifeCycleKey) {
-      return lifeCycle as! ViewControllerLifeCycle
+      return lifeCycle as! ViewControllerLifecycle
     } else {
-      let lifeCycle = ViewControllerLifeCycle(viewController: self)
+      let lifeCycle = ViewControllerLifecycle(viewController: self)
       objc_setAssociatedObject(
         self,
         &AssociatedKeys.viewControllerLifeCycleKey,

--- a/Sources/Bond/Shared/ViewControllerLifecycle.swift
+++ b/Sources/Bond/Shared/ViewControllerLifecycle.swift
@@ -10,37 +10,27 @@ import Foundation
 import UIKit
 import ReactiveKit
 
+public enum LifecycleEvent {
+    case viewDidLoad
+    case viewWillAppear
+    case viewDidAppear
+    case viewWillDisappear
+    case viewDidDisappear
+    case viewDidLayoutSubviews
+    case viewWillLayoutSubviews
+}
+
 /// Observe UIViewController life cycle events
 public final class ViewControllerLifecycle {
     
     private let wrapperViewController: WrapperViewController
     
-    public var viewDidLoad: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewDidLoad)
+    public var lifecycleEvents: Signal<LifecycleEvent, Never> {
+        self.wrapperViewController.lifecycleEvents
     }
     
-    public var viewWillAppear: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewWillAppear)
-    }
-    
-    public var viewDidAppear: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewDidAppear)
-    }
-    
-    public var viewWillDisappear: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewWillDisappear)
-    }
-    
-    public var viewDidDisappear: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewDidDisappear)
-    }
-    
-    public var viewWillLayoutSubviews: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewWillLayoutSubviews)
-    }
-    
-    public var viewDidLayoutSubviews: SafeSignal<Void> {
-        return self.wrapperViewController.lifecycleEvent(.viewDidLayoutSubviews)
+    public func lifecycleEvent(_ event: LifecycleEvent) -> Signal<Void, Never> {
+        self.wrapperViewController.lifecycleEvent(event)
     }
     
     public init(viewController: UIViewController) {
@@ -53,7 +43,7 @@ public final class ViewControllerLifecycle {
                 .keyPath(\.view, startWithCurrentValue: false)
                 .prefix(maxLength: 1)
                 .bind(to: viewController) { (viewController, _) in
-                    self.addAsChildViewController(viewController) // weak self ?
+                    self.addAsChildViewController(viewController)
             }
         }
     }
@@ -72,15 +62,6 @@ private extension ViewControllerLifecycle {
     
     final class WrapperViewController: UIViewController {
         
-        public enum LifecycleEvent {
-            case viewDidLoad
-            case viewWillAppear
-            case viewDidAppear
-            case viewWillDisappear
-            case viewDidDisappear
-            case viewDidLayoutSubviews
-            case viewWillLayoutSubviews
-        }
         
         deinit {
             _lifecycleEvent.send(completion: .finished)
@@ -163,32 +144,11 @@ extension UIViewController: ViewControllerLifecycleProvider {
 }
 
 extension ReactiveExtensions where Base: ViewControllerLifecycleProvider {
-    
-    var viewDidLoad: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewDidLoad
+    public var lifecycleEvents: Signal<LifecycleEvent, Never> {
+        self.base.viewControllerLifecycle.lifecycleEvents
     }
-    
-    var viewWillAppear: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewWillAppear
-    }
-    
-    var viewDidAppear: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewDidAppear
-    }
-    
-    var viewWillDisappear: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewWillDisappear
-    }
-    
-    var viewDidDisappear: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewDidDisappear
-    }
-    
-    var viewWillLayoutSubviews: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewWillLayoutSubviews
-    }
-    
-    var viewDidLayoutSubviews: SafeSignal<Void> {
-        return self.base.viewControllerLifecycle.viewDidLayoutSubviews
+
+    public func lifecycleEvent(_ event: LifecycleEvent) -> Signal<Void, Never> {
+        self.base.viewControllerLifecycle.lifecycleEvent(event)
     }
 }


### PR DESCRIPTION
## Introduction

Observing `UIViewController` life cycle using signals without subclassing or swizzling.

## Motivation

Usually we want to execute or combine a Rx flow on viewWillAppear/Disappear or any view controller method and there is no way in bond framework to observe this. 

## Proposed solution

The proposed solution is to create a wrapper view controller with `.zero` as frame (this is a cheap operation) then add it as child controller to the controller we want to observe. The parent controller will forward the life cycle events to the child so we can observe what is happening. The only trick we need to take into consideration is not to add the wrapper view controller if the parent one has not yet initialised its view, we can avoid that by observing the `\.view` keypath on the parent controller, one we got the view we add the wrapper as child controller.

## Detailed design

```swift
import Foundation
import UIKit
import ReactiveKit

public enum LifecycleEvent {
    case viewDidLoad
    case viewWillAppear
    case viewDidAppear
    case viewWillDisappear
    case viewDidDisappear
    case viewDidLayoutSubviews
    case viewWillLayoutSubviews
}

/// Observe UIViewController life cycle events
public final class ViewControllerLifecycle {
    
    private let wrapperViewController: WrapperViewController
    
    public var lifecycleEvents: Signal<LifecycleEvent, Never> {
        self.wrapperViewController.lifecycleEvents
    }
    
    public func lifecycleEvent(_ event: LifecycleEvent) -> Signal<Void, Never> {
        self.wrapperViewController.lifecycleEvent(event)
    }
    
    public init(viewController: UIViewController) {
        self.wrapperViewController = WrapperViewController()
        if viewController.isViewLoaded {
            self.addAsChildViewController(viewController)
        } else {
            viewController
                .reactive
                .keyPath(\.view, startWithCurrentValue: false)
                .prefix(maxLength: 1)
                .bind(to: viewController) { (viewController, _) in
                    self.addAsChildViewController(viewController)
            }
        }
    }
    
    private func addAsChildViewController(_ viewController: UIViewController) {
        
        viewController.addChild(self.wrapperViewController)
        viewController.view.addSubview(self.wrapperViewController.view)
        self.wrapperViewController.view.frame = .zero
        self.wrapperViewController.view.autoresizingMask = []
        self.wrapperViewController.didMove(toParent: viewController)
    }
}

private extension ViewControllerLifecycle {
    
    final class WrapperViewController: UIViewController {
        
        
        deinit {
            _lifecycleEvent.send(completion: .finished)
        }
        
        private let _lifecycleEvent = PassthroughSubject<LifecycleEvent, Never>()
        
        public var lifecycleEvents: Signal<LifecycleEvent, Never> {
            var signal = _lifecycleEvent.toSignal()
            if isViewLoaded {
                signal = signal.prepend(.viewDidLoad)
            }
            return signal
        }
        
        public func lifecycleEvent(_ event: LifecycleEvent) -> Signal<Void, Never> {
            return lifecycleEvents.filter { $0 == event }.eraseType()
        }
        
        //MARK: - Overrides
        override func viewDidLoad() {
            super.viewDidLoad()
            _lifecycleEvent.send(.viewDidLoad)
        }
        
        override func viewWillAppear(_ animated: Bool) {
            super.viewWillAppear(animated)
            _lifecycleEvent.send(.viewWillAppear)
        }
        
        override func viewDidAppear(_ animated: Bool) {
            super.viewDidAppear(animated)
            _lifecycleEvent.send(.viewDidAppear)
        }
        
        override func viewWillDisappear(_ animated: Bool) {
            super.viewWillDisappear(animated)
            _lifecycleEvent.send(.viewWillDisappear)
        }
        
        override func viewDidDisappear(_ animated: Bool) {
            super.viewDidDisappear(animated)
            _lifecycleEvent.send(.viewDidDisappear)
        }
        
        override func viewWillLayoutSubviews() {
            super.viewWillLayoutSubviews()
            _lifecycleEvent.send(.viewWillLayoutSubviews)
        }
        
        override func viewDidLayoutSubviews() {
            super.viewDidLayoutSubviews()
            _lifecycleEvent.send(.viewDidLayoutSubviews)
        }
    }
}

public protocol ViewControllerLifecycleProvider: class {
    var viewControllerLifecycle: ViewControllerLifecycle { get }
}

extension UIViewController: ViewControllerLifecycleProvider {
    
    private struct AssociatedKeys {
        static var viewControllerLifeCycleKey = "viewControllerLifeCycleKey"
    }
    
    public var viewControllerLifecycle: ViewControllerLifecycle {
        if let lifeCycle = objc_getAssociatedObject(self, &AssociatedKeys.viewControllerLifeCycleKey) {
            return lifeCycle as! ViewControllerLifecycle
        } else {
            let lifeCycle = ViewControllerLifecycle(viewController: self)
            objc_setAssociatedObject(
                self,
                &AssociatedKeys.viewControllerLifeCycleKey,
                lifeCycle, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
            return lifeCycle
        }
    }
}

extension ReactiveExtensions where Base: ViewControllerLifecycleProvider {
    public var lifecycleEvents: Signal<LifecycleEvent, Never> {
        self.base.viewControllerLifecycle.lifecycleEvents
    }

    public func lifecycleEvent(_ event: LifecycleEvent) -> Signal<Void, Never> {
        self.base.viewControllerLifecycle.lifecycleEvent(event)
    }
}
```

### Usage

```swift
anyViewControllerInstance.reactive.lifecycleEvent(.viewWillAppear).observeNext {  }
anyViewControllerInstance.reactive.lifecycleEvent.observeNext { event in enum that containts the available events }
```