### PR TITLE
Make the project compile for AppKit/macOS again

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 /* Begin PBXBuildFile section */
 		070FE2741F0138180031B7BD /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D2A1E8F0B1D000077C8 /* NSLayoutConstraint.swift */; };
 		070FE2781F0138190031B7BD /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D2A1E8F0B1D000077C8 /* NSLayoutConstraint.swift */; };
-		0856892E2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0856892D2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift */; };
+		0856892E2426BC1D002ACEE7 /* ViewControllerLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0856892D2426BC1D002ACEE7 /* ViewControllerLifecycle.swift */; };
 		16210A461D3EC474004AEDF3 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16210A3C1D3EC474004AEDF3 /* Bond.framework */; };
 		16887E3A1D744ABB00EDA099 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16887E391D744ABB00EDA099 /* AppDelegate.swift */; };
 		16887E441D744ABB00EDA099 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 16887E421D744ABB00EDA099 /* LaunchScreen.storyboard */; };
@@ -383,7 +383,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0856892D2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerLifeCycle.swift; sourceTree = "<group>"; };
+		0856892D2426BC1D002ACEE7 /* ViewControllerLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerLifecycle.swift; sourceTree = "<group>"; };
 		161D6D2D1D6F0D92004CA17D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		16210A3C1D3EC474004AEDF3 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		16210A451D3EC474004AEDF3 /* BondTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -717,6 +717,7 @@
 		90C04D571E8F0B4A000077C8 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				EC86E9AE1E9145CC008563B2 /* UIAccessibilityIdentification.swift */,
 				90C04D3F1E8F0B1D000077C8 /* UIActivityIndicatorView.swift */,
 				90C04D401E8F0B1D000077C8 /* UIApplication.swift */,
 				90C04D411E8F0B1D000077C8 /* UIBarButtonItem.swift */,
@@ -729,13 +730,13 @@
 				90C04D471E8F0B1D000077C8 /* UIGestureRecognizer.swift */,
 				90C04D481E8F0B1D000077C8 /* UIImageView.swift */,
 				90C04D491E8F0B1D000077C8 /* UILabel.swift */,
-				EC86E9AE1E9145CC008563B2 /* UIAccessibilityIdentification.swift */,
 				90C04D4A1E8F0B1D000077C8 /* UINavigationBar.swift */,
 				90C04D4B1E8F0B1D000077C8 /* UINavigationItem.swift */,
 				E5BAF71121C68394008C78E2 /* UIPickerView.swift */,
 				E58FBB8C22187FD700339211 /* UIPickerView+DataSource.swift */,
 				90C04D4C1E8F0B1D000077C8 /* UIProgressView.swift */,
 				90C04D4D1E8F0B1D000077C8 /* UIRefreshControl.swift */,
+				75CA9E9120678E600011E5BB /* UISearchBar.swift */,
 				90C04D4E1E8F0B1D000077C8 /* UISegmentedControl.swift */,
 				90C04D4F1E8F0B1D000077C8 /* UISlider.swift */,
 				90C04D501E8F0B1D000077C8 /* UIStepper.swift */,
@@ -744,8 +745,8 @@
 				EC0D8D2A21C69BC6003F8EF2 /* UITableView+DataSource.swift */,
 				90C04D531E8F0B1D000077C8 /* UITextField.swift */,
 				90C04D541E8F0B1D000077C8 /* UITextView.swift */,
-				75CA9E9120678E600011E5BB /* UISearchBar.swift */,
 				90C04D551E8F0B1D000077C8 /* UIView.swift */,
+				0856892D2426BC1D002ACEE7 /* ViewControllerLifecycle.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -786,7 +787,6 @@
 				90C04D2A1E8F0B1D000077C8 /* NSLayoutConstraint.swift */,
 				90C04D2D1E8F0B1D000077C8 /* NSObject.swift */,
 				90C04D2C1E8F0B1D000077C8 /* NSObject+KVO.swift */,
-				0856892D2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1149,7 +1149,7 @@
 				E58FBB8D22187FD700339211 /* UIPickerView+DataSource.swift in Sources */,
 				90C04DBC1E8F0B97000077C8 /* UIRefreshControl.swift in Sources */,
 				ECBC51FA216163BA00BE80EC /* TreeNode.swift in Sources */,
-				0856892E2426BC1D002ACEE7 /* ViewControllerLifeCycle.swift in Sources */,
+				0856892E2426BC1D002ACEE7 /* ViewControllerLifecycle.swift in Sources */,
 				90B5F63B2269D6DD001917B4 /* NSCollectionView+DataSource.swift in Sources */,
 				90C04DBD1E8F0B97000077C8 /* UISegmentedControl.swift in Sources */,
 				ECFF44B12168C21F00B5EDB0 /* Array2D.swift in Sources */,

--- a/Sources/Bond/UIKit/ViewControllerLifecycle.swift
+++ b/Sources/Bond/UIKit/ViewControllerLifecycle.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Swift Bond. All rights reserved.
 //
 
+#if os(iOS) || os(tvOS)
+
 import Foundation
 import UIKit
 import ReactiveKit
@@ -152,3 +154,5 @@ extension ReactiveExtensions where Base: ViewControllerLifecycleProvider {
         self.base.viewControllerLifecycle.lifecycleEvent(event)
     }
 }
+
+#endif


### PR DESCRIPTION
This PR moves the UIViewController lifecycle additions back to the UIKit folder, and wraps them in a conditional compilation block so that macOS/AppKit builds again.