### PR TITLE
Set minimum deployment version to iOS 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Bond",
     platforms: [
-        .macOS(.v10_11), .iOS(.v8), .tvOS(.v9)
+        .macOS(.v10_11), .iOS(.v9), .tvOS(.v9)
     ],
     products: [
         .library(name: "Bond", targets: ["Bond"])


### PR DESCRIPTION
Xcode 12 doesn’t support 8 anymore and will fail to compile because Differ has iOS 9 as a minimum requirement.