### PR TITLE
Array2D conformance to Swift.Collection

### DIFF
--- a/Sources/Bond/Data Sources/SectionedDataSourceChangesetConvertible.swift
+++ b/Sources/Bond/Data Sources/SectionedDataSourceChangesetConvertible.swift
@@ -75,6 +75,12 @@ extension Array: SectionedDataSourceChangesetConvertible {
     }
 }
 
+extension Array2D: SectionedDataSourceChangesetConvertible {
+    public var asSectionedDataSourceChangeset: OrderedCollectionChangeset<Array2D> {
+        return OrderedCollectionChangeset(collection: self, patch: [])
+    }
+}
+
 extension OrderedCollectionChangeset: SectionedDataSourceChangeset where Diff.Index: SectionedDataIndexPathConvertable, Collection: SectionedDataSourceProtocol {}
 
 extension OrderedCollectionChangeset: SectionedDataSourceChangesetConvertible where Diff.Index: SectionedDataIndexPathConvertable, Collection: SectionedDataSourceProtocol {

--- a/Sources/Bond/Data Structures/Array2D.swift
+++ b/Sources/Bond/Data Structures/Array2D.swift
@@ -219,3 +219,37 @@ extension Array2D {
         }
     }
 }
+
+// MARK: - Sequence conformance
+
+extension Array2D: Swift.Sequence {
+    public typealias Iterator = IndexingIterator<[Array2D.Section]>
+    
+    public func makeIterator() -> Iterator {
+        return sections.makeIterator()
+    }
+}
+
+// MARK: - Collection conformance
+
+extension Array2D: Collection {
+    public typealias Index = Int
+    
+    public var startIndex: Index {
+        return sections.startIndex
+    }
+    
+    public var endIndex: Index {
+        return sections.endIndex
+    }
+    
+    public subscript(position: Index) -> Iterator.Element {
+        precondition(indices.contains(position), "out of bounds")
+        let element = sections[position]
+        return element
+    }
+    
+    public func index(after i: Index) -> Index {
+        return sections.index(after: i)
+    }
+}


### PR DESCRIPTION
## Feature proposal
I want to suggest you to extend `Array2D` with `Swift.Collection` to make it possible to use this collection in enhanced methods of `CollectionViews`

## Alternatives
Make own `Swift.Collection` and conform it to `QueryableSectionedDataSourceProtocol` and `SectionedDataSourceChangesetConvertible` protocols.

## Motivation
I have faced with this problem at my project, when I needed to implement sectioned table view with unique cells. It's possible to solve this problem with method `bind(to:animated:rowAnimation:createCell:)`, but only `SectionedDataSourceChangesetConvertible` collections are able to bind table view in such way. And framework have such one: `Swift.Array`. Its problem is `QueryableSectionedDataSourceProtocol` conformance, where it returns `numberOfSections` equal to 1.

For this issue very convenient to use `Array2D`, but it can't conform to `SectionedDataSourceChangesetConvertible` due to it's not a `Swift.Collection`

As a result I have created this pull request.

## Additional
Documentation or tests can be appended.