### PR TITLE
Project file uses SRCROOT; should be PROJECT_DIR #690

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -1099,7 +1099,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\nif [[ $SDKROOT == *\"iPhone\"* ]]; then\n    find \"${SRCROOT}/Carthage/Build/iOS/\" -name '*.framework' -exec cp -prv '{}' \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\" ';'\nelif [[ $SDKROOT == *\"AppleTV\"* ]]; then\n    find \"${SRCROOT}/Carthage/Build/tvOS/\" -name '*.framework' -exec cp -prv '{}' \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\" ';'\nelif [[ $SDKROOT == *\"Mac\"* ]]; then\n    find \"${SRCROOT}/Carthage/Build/Mac/\" -name '*.framework' -exec cp -prv '{}' \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\" ';'\nfi\n\n\n";
+			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\nif [[ $SDKROOT == *\"iPhone\"* ]]; then\n    find \"${PROJECT_DIR}/Carthage/Build/iOS/\" -name '*.framework' -exec cp -prv '{}' \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\" ';'\nelif [[ $SDKROOT == *\"AppleTV\"* ]]; then\n    find \"${PROJECT_DIR}/Carthage/Build/tvOS/\" -name '*.framework' -exec cp -prv '{}' \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\" ';'\nelif [[ $SDKROOT == *\"Mac\"* ]]; then\n    find \"${PROJECT_DIR}/Carthage/Build/Mac/\" -name '*.framework' -exec cp -prv '{}' \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\" ';'\nfi\n\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1626,7 +1626,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
+				SWIFT_INCLUDE_PATHS = "\"${PROJECT_DIR}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -1659,7 +1659,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
+				SWIFT_INCLUDE_PATHS = "\"${PROJECT_DIR}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1769,7 +1769,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
+				SWIFT_INCLUDE_PATHS = "\"${PROJECT_DIR}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -1805,7 +1805,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
+				SWIFT_INCLUDE_PATHS = "\"${PROJECT_DIR}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -1837,7 +1837,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
+				SWIFT_INCLUDE_PATHS = "\"${PROJECT_DIR}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -1872,7 +1872,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "\"${SRCROOT}/Sources/BNDProtocolProxyBase\"/**";
+				SWIFT_INCLUDE_PATHS = "\"${PROJECT_DIR}/Sources/BNDProtocolProxyBase\"/**";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;


### PR DESCRIPTION
This should have no effect for regular standalone builds, and enables embedded builds as a submodule in some build environments where SRCROOT is not per-project.