### PR TITLE
Support Mac Catalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Bond", targets: ["Bond"])
     ],
     dependencies: [
-        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.14.2")),
+        .package(url: "https://github.com/DeclarativeHub/ReactiveKit.git", .upToNextMajor(from: "3.18.1")),
         .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.4.3"))
     ],
     targets: [

--- a/Sources/Bond/AppKit/NSOutlineView+Changeset.swift
+++ b/Sources/Bond/AppKit/NSOutlineView+Changeset.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 import ReactiveKit

--- a/Sources/Bond/AppKit/NSOutlineView.swift
+++ b/Sources/Bond/AppKit/NSOutlineView.swift
@@ -22,7 +22,8 @@
 //  THE SOFTWARE.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
+
 import AppKit
 import ReactiveKit
 

--- a/Sources/Bond/AppKit/NSTableView+DataSource.swift
+++ b/Sources/Bond/AppKit/NSTableView+DataSource.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 import ReactiveKit


### PR DESCRIPTION
The `canImport(AppKit)` becomes true for Mac Catalyst targets as well. However you are not allowed to use these API's in a Catalyst app and so it can't compile. 

I am simply adding a check for macCatalyst to avoid this being imported into the target.