### PR TITLE
Changed `ViewControllerLifecycle` implementation using swizzling

### DIFF
--- a/Sources/Bond/UIKit/ViewControllerLifecycle.swift
+++ b/Sources/Bond/UIKit/ViewControllerLifecycle.swift
@@ -22,7 +22,7 @@ public extension ReactiveExtensions where Base: UIViewController {
     }
 }
 
-public enum LifecycleEvent: CaseIterable, Equatable {
+public enum LifecycleEvent: CaseIterable {
     case viewDidLoad
     case viewWillAppear
     case viewDidAppear
@@ -59,22 +59,20 @@ extension UIViewController {
     }
 
     private var lifecycleEventsSubject: Subject<LifecycleEvent, Never> {
-        get {
-            if let subject = objc_getAssociatedObject(
+        if let subject = objc_getAssociatedObject(
+            self,
+            &StaticVariables.lifecycleSubjectKey
+        ) as? Subject<LifecycleEvent, Never> {
+            return subject
+        } else {
+            let subject = PassthroughSubject<LifecycleEvent, Never>()
+            objc_setAssociatedObject(
                 self,
-                &StaticVariables.lifecycleSubjectKey
-            ) as? Subject<LifecycleEvent, Never> {
-                return subject
-            } else {
-                let subject = PassthroughSubject<LifecycleEvent, Never>()
-                objc_setAssociatedObject(
-                    self,
-                    &StaticVariables.lifecycleSubjectKey,
-                    subject,
-                    .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-                )
-                return subject
-            }
+                &StaticVariables.lifecycleSubjectKey,
+                subject,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+            return subject
         }
     }
 

--- a/Sources/Bond/UIKit/ViewControllerLifecycle.swift
+++ b/Sources/Bond/UIKit/ViewControllerLifecycle.swift
@@ -23,23 +23,11 @@ public extension ReactiveExtensions where Base: UIViewController {
 }
 
 public enum LifecycleEvent: CaseIterable, Equatable {
-    public static var allCases: [LifecycleEvent] {
-        return [
-            .viewDidLoad,
-            .viewWillAppear(false),
-            .viewDidAppear(false),
-            .viewWillDisappear(false),
-            .viewDidDisappear(false),
-            .viewWillLayoutSubviews,
-            .viewDidLayoutSubviews
-        ]
-    }
-
     case viewDidLoad
-    case viewWillAppear(Bool)
-    case viewDidAppear(Bool)
-    case viewWillDisappear(Bool)
-    case viewDidDisappear(Bool)
+    case viewWillAppear
+    case viewDidAppear
+    case viewWillDisappear
+    case viewDidDisappear
     case viewWillLayoutSubviews
     case viewDidLayoutSubviews
 
@@ -121,21 +109,8 @@ extension UIViewController {
                 .viewDidDisappear:
 
                 let newImplementation: @convention(block) (UnsafeRawPointer, Bool) -> Void = { me, animated in
-                    let event: LifecycleEvent
-                    switch lifecycle {
-                    case .viewWillAppear:
-                        event = .viewWillAppear(animated)
-                    case .viewDidAppear:
-                        event = .viewDidAppear(animated)
-                    case .viewWillDisappear:
-                        event = .viewWillDisappear(animated)
-                    case .viewDidDisappear:
-                        event = .viewDidDisappear(animated)
-                    default:
-                        fatalError("Received unexpected lifecycle event")
-                    }
                     let viewController = unsafeBitCast(me, to: UIViewController.self)
-                    viewController.lifecycleEventsSubject.send(event)
+                    viewController.lifecycleEventsSubject.send(lifecycle)
                     unsafeBitCast(existingImplementation, to: _IMP_BOOL.self)(me, selector, animated)
                 }
                 let swizzled = imp_implementationWithBlock(newImplementation)

--- a/Tests/BondTests/ViewControllerLifecycleTests.swift
+++ b/Tests/BondTests/ViewControllerLifecycleTests.swift
@@ -1,0 +1,156 @@
+#if os(iOS) || os(tvOS)
+
+import XCTest
+import ReactiveKit
+@testable import Bond
+
+class ViewControllerLifecycleTests: XCTestCase {
+
+    func testViewDidLoad() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewDidLoad()
+        XCTAssertEqual(accumulator.values, [.viewDidLoad])
+    }
+
+    func testViewWillAppear() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewWillAppear(false)
+        sut.viewWillAppear(true)
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewWillAppear(false),
+                .viewWillAppear(true)
+            ]
+        )
+    }
+
+    func testViewDidAppear() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewDidAppear(false)
+        sut.viewDidAppear(true)
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewDidAppear(false),
+                .viewDidAppear(true)
+            ]
+        )
+    }
+
+    func testViewWillDisappear() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewWillDisappear(false)
+        sut.viewWillDisappear(true)
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewWillDisappear(false),
+                .viewWillDisappear(true)
+            ]
+        )
+    }
+
+    func testViewDidDisappear() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewDidDisappear(false)
+        sut.viewDidDisappear(true)
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewDidDisappear(false),
+                .viewDidDisappear(true)
+            ]
+        )
+    }
+
+    func testViewWillLayoutSubviews() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewWillLayoutSubviews()
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewWillLayoutSubviews
+            ]
+        )
+    }
+
+    func testViewDidLayoutSubviews() {
+        let sut = UIViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewDidLayoutSubviews()
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewDidLayoutSubviews
+            ]
+        )
+    }
+
+    func testCustomViewController() {
+
+        class TestViewController: UIViewController {
+            override func viewDidLoad() {
+                super.viewDidLoad()
+            }
+
+            override func viewWillAppear(_ animated: Bool) {
+                super.viewWillAppear(animated)
+            }
+
+            override func viewWillLayoutSubviews() {
+                super.viewWillLayoutSubviews()
+            }
+
+            override func viewDidLayoutSubviews() {
+                super.viewDidLayoutSubviews()
+            }
+
+            override func viewDidAppear(_ animated: Bool) {
+                super.viewDidAppear(animated)
+            }
+
+            override func viewWillDisappear(_ animated: Bool) {
+                super.viewWillDisappear(animated)
+            }
+
+            override func viewDidDisappear(_ animated: Bool) {
+                super.viewDidDisappear(animated)
+            }
+        }
+
+        let sut = TestViewController()
+        let accumulator = Subscribers.Accumulator<LifecycleEvent, Never>()
+        sut.reactive.lifecycleEvents.subscribe(accumulator)
+        sut.viewDidLoad()
+        sut.viewWillAppear(false)
+        sut.viewWillLayoutSubviews()
+        sut.viewDidLayoutSubviews()
+        sut.viewDidAppear(false)
+        XCTAssertEqual(
+            accumulator.values,
+            [
+                .viewDidLoad,
+                .viewWillAppear(false),
+                .viewWillLayoutSubviews,
+                .viewDidLayoutSubviews,
+                .viewDidAppear(false)
+            ]
+        )
+    }
+}
+
+#endif

--- a/Tests/BondTests/ViewControllerLifecycleTests.swift
+++ b/Tests/BondTests/ViewControllerLifecycleTests.swift
@@ -23,8 +23,8 @@ class ViewControllerLifecycleTests: XCTestCase {
         XCTAssertEqual(
             accumulator.values,
             [
-                .viewWillAppear(false),
-                .viewWillAppear(true)
+                .viewWillAppear,
+                .viewWillAppear
             ]
         )
     }
@@ -38,8 +38,8 @@ class ViewControllerLifecycleTests: XCTestCase {
         XCTAssertEqual(
             accumulator.values,
             [
-                .viewDidAppear(false),
-                .viewDidAppear(true)
+                .viewDidAppear,
+                .viewDidAppear
             ]
         )
     }
@@ -53,8 +53,8 @@ class ViewControllerLifecycleTests: XCTestCase {
         XCTAssertEqual(
             accumulator.values,
             [
-                .viewWillDisappear(false),
-                .viewWillDisappear(true)
+                .viewWillDisappear,
+                .viewWillDisappear
             ]
         )
     }
@@ -68,8 +68,8 @@ class ViewControllerLifecycleTests: XCTestCase {
         XCTAssertEqual(
             accumulator.values,
             [
-                .viewDidDisappear(false),
-                .viewDidDisappear(true)
+                .viewDidDisappear,
+                .viewDidDisappear
             ]
         )
     }
@@ -144,10 +144,10 @@ class ViewControllerLifecycleTests: XCTestCase {
             accumulator.values,
             [
                 .viewDidLoad,
-                .viewWillAppear(false),
+                .viewWillAppear,
                 .viewWillLayoutSubviews,
                 .viewDidLayoutSubviews,
-                .viewDidAppear(false)
+                .viewDidAppear
             ]
         )
     }


### PR DESCRIPTION
Hello! This PR changes `ViewControllerLifecycle` implementation to a swizzling based approach because I noticed some issues with the existing child view controller approach:
- If you have a `UINavigationController` and you start observing the events on it, the `rootViewController` of the navigation controller will be swapped with a `WrapperViewController` resulting in an empty view. `TabBarController` is potentially open to same type of issue.
- If you are implementing a container view controller and need to also observe its lifecycle via reactive the `children` array could become hard to manage.
- Some crash detection libraries inspects the view hierarchy when a crash happens and if there is a view controller containing the `WrapperViewController` as child, the stack trace messages become hard to understand because of these `WrapperViewController` noise.

I don't like that this solution is based on swizzling but I believe there's no easy way to address this without creating a base `UIViewController` subclass that all the other VCs have to subclass. 
This piece of code was also untested and I added some tests on top of it now, let me know if you see any issue!

cc @ibrahimkteish 
